### PR TITLE
Hero creator

### DIFF
--- a/src/.env
+++ b/src/.env
@@ -1,2 +1,1 @@
-VITE_BM_HOST_REFERRER=coddemo.boardmeister.com
-VITE_BM_BASE_URL=https://vizier.boardmeister.com/
+VITE_HERO_CREATOR_FILE_URL=

--- a/src/.env
+++ b/src/.env
@@ -1,0 +1,2 @@
+VITE_BM_HOST_REFERRER=coddemo.boardmeister.com
+VITE_BM_BASE_URL=https://vizier.boardmeister.com/

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -56,6 +56,7 @@ declare module 'vue' {
     ForgotPassword: typeof import('./components/ForgotPassword.vue')['default']
     FriendStore: typeof import('./components/FriendStore.vue')['default']
     FriendStoreList: typeof import('./components/FriendStoreList.vue')['default']
+    HeroCreator: typeof import('./components/HeroCreator/HeroCreator.vue')['default']
     HeroDetailView: typeof import('./components/HeroDetailView.vue')['default']
     ItemCardSelect: typeof import('./components/ItemCardSelect.vue')['default']
     ItemCardSelectCategorized: typeof import('./components/ItemCardSelectCategorized.vue')['default']

--- a/src/components/HeroCreator/HeroCreator.vue
+++ b/src/components/HeroCreator/HeroCreator.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import Marshal, { RegisterConfig } from '@boardmeister/marshal';
+import Herald from '@boardmeister/herald';
+import Minstrel from '@boardmeister/minstrel';
+import Core, {
+  InitEvent,
+  Event as CoreEvent,
+  Layout,
+  ISettings,
+  Modules,
+  ModulesEvent
+} from '@boardmeister/antetype-core';
+import Conditions from '@boardmeister/antetype-conditions';
+import Illustrator from '@boardmeister/antetype-illustrator';
+import Workspace from '@boardmeister/antetype-workspace';
+import Transform from '@boardmeister/antetype-transform';
+import Cursor from '@boardmeister/antetype-cursor';
+import Treasurer from '@boardmeister/treasurer';
+import Diemut from '@boardmeister/diemut';
+import Guard from '@boardmeister/guard';
+
+let canvas = ref(null);
+const version = '1.0.0';
+const namespace = 'boardmeister';
+const generateModuleConfig = (source: object, name: string, args: unknown[] = []): RegisterConfig => ({
+  entry: {
+    source,
+    namespace: namespace,
+    name,
+    version: version,
+    arguments: args,
+  },
+  type: 'module',
+  tags: ['subscriber'],
+  resource: {
+    src: '/bm/cdn/' + name + '/dist/'
+  },
+  asset: {
+    src: '/bm/cdn/' + name + '/asset/'
+  }
+})
+let antetypeModules: Modules = {};
+const modules: RegisterConfig[] = [
+  generateModuleConfig(Herald, 'herald'),
+  generateModuleConfig(Minstrel, 'minstrel'),
+  generateModuleConfig(Guard, 'guard'),
+  generateModuleConfig(Diemut, 'diemut', [
+    {
+      baseURL: '/bm/vizier/',
+      headers: { 'X-HOST-REFERRER': 'cod-app.boardmeister.local' } // @TODO env variable
+    }
+  ]),
+  generateModuleConfig(Treasurer, 'treasurer', ['_/']),
+  generateModuleConfig(Core, 'antetype-core'),
+  generateModuleConfig(Conditions, 'antetype-conditions'),
+  generateModuleConfig(Illustrator, 'antetype-illustrator'),
+  generateModuleConfig(Workspace, 'antetype-workspace'),
+  generateModuleConfig(Transform, 'antetype-transform'),
+  generateModuleConfig(Cursor, 'antetype-cursor'),
+];
+const marshal = new Marshal();
+for (const module of modules) {
+  marshal.register(module);
+}
+const getHerald = (): typeof Herald => marshal.get('boardmeister/herald');
+const getTreasurer = (): typeof Herald => marshal.get('boardmeister/treasurer');
+const loadModules = async (): Promise<Modules> => {
+  const event = new CustomEvent<ModulesEvent>(CoreEvent.MODULES, { detail: { modules: {}, canvas: canvas.value }});
+  await getHerald().dispatch(event);
+  antetypeModules = event.detail.modules as Modules;
+
+  return antetypeModules;
+}
+
+const initAntetype = async (base: Layout, settings: ISettings): Promise<void> => {
+  await getHerald().dispatch(new CustomEvent<InitEvent>(CoreEvent.INIT, { detail: { base, settings } }));
+}
+
+onMounted(async (): Promise<void> => {
+  try {
+    await marshal.load()
+    await loadModules();
+
+    const payload = await getTreasurer().get({
+      document: 'template',
+      namespace: 'boardmeister',
+      name: 'antetype',
+      id: '6798ed1c0be82c03620a63b2', // @TODO pass as env variable
+      dataset: [
+        'data',
+        'settings',
+      ]
+    });
+    const layout = JSON.parse(payload.data);
+    const settings = JSON.parse(payload.settings);
+    await initAntetype(layout, settings);
+  } catch (e) {
+    console.info('Handle errors', e)
+    throw e;
+  }
+})
+
+</script>
+
+<template>
+  <v-container max-width="800" class="flex" align="center">
+    <canvas ref="canvas" class="h-screen" style="aspect-ratio: 767 / 1169; max-height: 90vh;"/>
+  </v-container>
+</template>
+
+<style scoped>
+
+</style>

--- a/src/components/HeroCreator/HeroCreator.vue
+++ b/src/components/HeroCreator/HeroCreator.vue
@@ -1,114 +1,372 @@
 <script setup lang="ts">
 import { ref, onMounted } from "vue";
 import Marshal, { RegisterConfig } from '@boardmeister/marshal';
-import Herald from '@boardmeister/herald';
+import { Herald } from '@boardmeister/herald';
 import Minstrel from '@boardmeister/minstrel';
-import Core, {
+import {
   InitEvent,
   Event as CoreEvent,
   Layout,
   ISettings,
-  Modules,
-  ModulesEvent
+  ModulesEvent,
+  CloseEvent,
 } from '@boardmeister/antetype-core';
-import Conditions from '@boardmeister/antetype-conditions';
-import Illustrator from '@boardmeister/antetype-illustrator';
-import Workspace from '@boardmeister/antetype-workspace';
-import Transform from '@boardmeister/antetype-transform';
-import Cursor from '@boardmeister/antetype-cursor';
-import Treasurer from '@boardmeister/treasurer';
+import Core from '@boardmeister/antetype-core/dist/core';
+import { IConditionAwareDef } from '@boardmeister/antetype-conditions';
+import Conditions from '@boardmeister/antetype-conditions/dist/module';
+import Illustrator from '@boardmeister/antetype-illustrator/dist/module';
+import Workspace from '@boardmeister/antetype-workspace/dist/module';
+import Transform from '@boardmeister/antetype-transform/dist/module';
+import Cursor from '@boardmeister/antetype-cursor/dist/module';
+import { Treasurer } from '@boardmeister/treasurer';
 import Diemut from '@boardmeister/diemut';
 import Guard from '@boardmeister/guard';
+import { IInputComponent, ITemplateDesignerModules } from '@/type/templateDesigner';
+import ActiveLayersHandler, { Event as ActiveLayerEvent, LayerActivationEvent }
+  from "@/service/TemplateDesigner/ActiveLayersHandler";
+import { handleSelectInput } from "@/components/HeroCreator/Input/Select";
+import Title from "@/components/HeroCreator/Input/Title.vue";
+import Multiselect from "@/components/HeroCreator/Input/Multiselect.vue";
+import { handleImageInput } from "@/components/HeroCreator/Input/Image";
 
-let canvas = ref(null);
+interface IInputModal {
+  width: number|null;
+  height: number|null;
+  left: number;
+  top: number|null;
+  bottom: number|null;
+}
+
+let canvas = ref<HTMLCanvasElement|null>(null);
 const version = '1.0.0';
 const namespace = 'boardmeister';
 const generateModuleConfig = (source: object, name: string, args: unknown[] = []): RegisterConfig => ({
   entry: {
     source,
-    namespace: namespace,
+    namespace,
     name,
-    version: version,
+    version,
     arguments: args,
   },
   type: 'module',
   tags: ['subscriber'],
-  resource: {
-    src: '/bm/cdn/' + name + '/dist/'
-  },
-  asset: {
-    src: '/bm/cdn/' + name + '/asset/'
-  }
 })
-let antetypeModules: Modules = {};
+const inputModal = ref<IInputModal>({
+  width: null,
+  height: null,
+  left: 0,
+  top: 0,
+  bottom: null,
+});
+const inputsCon = ref<HTMLDivElement|null>(null);
+const downloadLoading = ref(false);
+const ratioWidth = ref(1);
+const ratioHeight = ref(1);
+const inputs = ref<IInputComponent[]>([]);
+let activeLayersHandler: ActiveLayersHandler;
+let antetypeModules: ITemplateDesignerModules;
 const modules: RegisterConfig[] = [
   generateModuleConfig(Herald, 'herald'),
   generateModuleConfig(Minstrel, 'minstrel'),
   generateModuleConfig(Guard, 'guard'),
   generateModuleConfig(Diemut, 'diemut', [
     {
-      baseURL: '/bm/vizier/',
-      headers: { 'X-HOST-REFERRER': 'cod-app.boardmeister.local' } // @TODO env variable
+      baseURL: import.meta.env.VITE_BM_BASE_URL,
+      headers: { 'X-HOST-REFERRER': import.meta.env.VITE_BM_HOST_REFERRER }
     }
   ]),
   generateModuleConfig(Treasurer, 'treasurer', ['_/']),
-  generateModuleConfig(Core, 'antetype-core'),
-  generateModuleConfig(Conditions, 'antetype-conditions'),
-  generateModuleConfig(Illustrator, 'antetype-illustrator'),
-  generateModuleConfig(Workspace, 'antetype-workspace'),
-  generateModuleConfig(Transform, 'antetype-transform'),
-  generateModuleConfig(Cursor, 'antetype-cursor'),
 ];
 const marshal = new Marshal();
 for (const module of modules) {
   marshal.register(module);
 }
-const getHerald = (): typeof Herald => marshal.get('boardmeister/herald');
-const getTreasurer = (): typeof Herald => marshal.get('boardmeister/treasurer');
-const loadModules = async (): Promise<Modules> => {
+const getHerald = (): Herald => marshal.get('boardmeister/herald')!;
+const getTreasurer = (): Treasurer => marshal.get('boardmeister/treasurer')!;
+const manuallyRegisterModules = (): void => {
+  // @TODO unregister this on onmounted
+  const herald = getHerald();
+
+  const unregister = herald.batch([
+    {
+      event: CoreEvent.MODULES,
+      subscription: (event) => {
+        const { modules, canvas } = event.detail;
+        modules.core = Core({ canvas, modules, herald });
+        modules.workspace = new Workspace(canvas, modules, herald);
+        modules.transform = new Transform(canvas, modules, herald);
+        modules.illustrator = new Illustrator(canvas, modules, herald);
+        modules.cursor = Cursor({ canvas, modules, herald });
+        modules.conditions = Conditions({ canvas, modules, herald });
+      }
+    },
+    {
+      event: CoreEvent.CLOSE,
+      subscription: () => {
+        unregister();
+      }
+    }
+  ])
+}
+const loadModules = async (): Promise<ITemplateDesignerModules> => {
   const event = new CustomEvent<ModulesEvent>(CoreEvent.MODULES, { detail: { modules: {}, canvas: canvas.value }});
   await getHerald().dispatch(event);
-  antetypeModules = event.detail.modules as Modules;
 
-  return antetypeModules;
+  return event.detail.modules as ITemplateDesignerModules;
 }
 
 const initAntetype = async (base: Layout, settings: ISettings): Promise<void> => {
   await getHerald().dispatch(new CustomEvent<InitEvent>(CoreEvent.INIT, { detail: { base, settings } }));
 }
 
+const setCursorSettings = (settings: ISettings): void => {
+  if (!settings.cursor) {
+    settings.cursor = {} as Record<string, any>;
+  }
+  const cursor = settings.cursor as any;
+  for (const name of ['select', 'delete', 'resize']) {
+    if (!cursor[name]) {
+      cursor[name] = {};
+    }
+    cursor[name].disabled = true;
+  }
+
+  if (!cursor.detect) {
+    cursor.detect = {};
+  }
+
+  if (!cursor.detect.move) {
+    cursor.detect.move = {};
+  }
+
+  cursor.detect.move.skipSelection = true;
+}
+
+const downloadCard = async (): Promise<void> => {
+  try {
+    if (downloadLoading.value || !antetypeModules) {
+      return;
+    }
+
+    downloadLoading.value = true;
+    await antetypeModules.workspace.download({ filename: 'monster', dpi: 100 });
+  } catch (e) {
+    console.info('Handle errors', e)
+    throw e;
+  } finally {
+    downloadLoading.value = false;
+  }
+}
+
+const getLayerAbsoluteX = (layer: IConditionAwareDef): number => {
+  let x = layer.start.x;
+
+  if (layer.hierarchy?.parent) {
+      x += getLayerAbsoluteX(layer.hierarchy?.parent)
+  }
+
+  return x;
+}
+
+const getLayerAbsoluteY = (layer: IConditionAwareDef): number => {
+  let x = layer.start.y;
+
+  if (layer.hierarchy?.parent) {
+      x += getLayerAbsoluteY(layer.hierarchy?.parent)
+  }
+
+  return x;
+}
+
+const onLayerActivated = async (e: LayerActivationEvent) => {
+  const { origin, layer } = e.detail;
+  inputs.value = [];
+  if (layer === null) {
+    return;
+  }
+
+  const clone = antetypeModules.core.clone.getClone(layer);
+  const layerAbsX = getLayerAbsoluteX(clone);
+  let left = canvas.value!.offsetLeft + layerAbsX;
+  const layerAbsY = getLayerAbsoluteY(clone);
+  let top: number|null = canvas.value!.offsetTop + layerAbsY + clone.size.h;
+  let bottom: number|null = null;
+  let width: number|null = clone.size.w;
+  let height: number|null = null;
+
+  const fullHeight = antetypeModules.workspace.calc('100h%');
+  const fullWidth = antetypeModules.workspace.calc('100w%');
+  const hasMoreSpaceAtTheTop = fullHeight - layerAbsY - clone.size.h < fullHeight/2;
+  const hasMoreSpaceAtTheLeft = fullWidth - layerAbsX - clone.size.w < fullWidth/2;
+  if (hasMoreSpaceAtTheTop) {
+    top = null;
+    bottom = canvas.value!.offsetTop + fullHeight - layerAbsY;
+  }
+
+  if (clone.size.h > width) {
+    top = layerAbsY;
+    bottom = null;
+    if (hasMoreSpaceAtTheLeft) {
+      left -= width;
+    } else {
+      left += width;
+    }
+    width = null;
+    height = clone.size.h;
+  }
+
+  inputModal.value = {
+    left,
+    top,
+    bottom,
+    width,
+    height,
+  };
+  const inputTypeToComponent: Record<string, object> = {
+    'select': handleSelectInput,
+    'multiselect': Multiselect,
+    'title': Title,
+    'image': handleImageInput,
+  }
+  const newInputs: IInputComponent[] = [];
+  for (const input of layer.conditions?.inputs ?? []) {
+    const inputHandle = inputTypeToComponent[input.type];
+    if (!inputHandle) {
+      continue;
+    }
+
+    const inputProps = {
+      component: inputTypeToComponent[input.type],
+      input,
+      origin,
+      layer,
+      modules: antetypeModules,
+    } as IInputComponent;
+    if (typeof inputHandle == 'function') {
+      inputHandle(inputProps)
+      continue;
+    }
+
+    newInputs.push(inputProps)
+  }
+  nextTick(() => {
+    inputs.value = newInputs;
+  });
+}
+
+const handleLayerActivationSubscriptions = (): void => {
+  const herald = getHerald();
+  const unregister = herald.batch([
+    {
+      event: CoreEvent.CLOSE,
+      subscription: () => {
+        unregister();
+      }
+    },
+    {
+      event: ActiveLayerEvent.LayerActivated,
+      subscription: onLayerActivated,
+    }
+  ])
+}
+
+const hideInputsOnClickOutsideCanvas = (e: MouseEvent) => {
+  if (
+    e.target != canvas.value
+    && e.target != inputsCon.value
+    && !inputsCon.value?.contains(e.target as Node)
+  ) {
+    inputs.value = [];
+  }
+}
+
+const getInputModalCoords = (): string => {
+  const coords = inputModal.value;
+  let result = 'left:' + coords.left + 'px;';
+  if (coords.top) {
+    result += 'top:' + coords.top + 'px;';
+  } else if (coords.bottom) {
+    result += 'bottom:' + coords.bottom + 'px;';
+  }
+
+  if (coords.width) {
+    result += 'width:' + coords.width + 'px;';
+  }
+
+  if (coords.height) {
+    result += 'height:' + coords.height + 'px;';
+  }
+
+  return result;
+}
+
+onUnmounted(() => {
+  void getHerald().dispatch(new CustomEvent<CloseEvent>(CoreEvent.CLOSE));
+  document.body.removeEventListener('click', hideInputsOnClickOutsideCanvas, false);
+});
+
 onMounted(async (): Promise<void> => {
   try {
+    document.body.addEventListener('click', hideInputsOnClickOutsideCanvas, false);
+    (canvas.value! as HTMLCanvasElement).addEventListener('contextmenu', e => { e.preventDefault(); });
     await marshal.load()
-    await loadModules();
+    manuallyRegisterModules();
+    antetypeModules = await loadModules();
 
-    const payload = await getTreasurer().get({
+    const payload = await getTreasurer().get<{
+      _id: string;
+      data: string;
+      settings: string;
+    }>({
       document: 'template',
       namespace: 'boardmeister',
       name: 'antetype',
-      id: '6798ed1c0be82c03620a63b2', // @TODO pass as env variable
+      id: import.meta.env.VITE_BM_HERO_ID,
       dataset: [
         'data',
         'settings',
       ]
     });
+    handleLayerActivationSubscriptions();
     const layout = JSON.parse(payload.data);
     const settings = JSON.parse(payload.settings);
+    const { workspace: { height, width } } = settings;
+
+    ratioWidth.value = width;
+    ratioHeight.value = height;
+
+    setCursorSettings(settings);
     await initAntetype(layout, settings);
+    activeLayersHandler = new ActiveLayersHandler(getHerald(), antetypeModules, canvas.value!);
   } catch (e) {
     console.info('Handle errors', e)
     throw e;
   }
 })
-
 </script>
 
 <template>
-  <v-container max-width="800" class="flex" align="center">
-    <canvas ref="canvas" class="h-screen" style="aspect-ratio: 767 / 1169; max-height: 90vh;"/>
+  <v-container class="d-flex justify-center align-center">
+    <v-card class="px-3 py-3 d-block mx-auto w-100 text-center" style="max-width:300px;" @click="downloadCard">
+      <span v-if="downloadLoading">Loading...</span>
+      <span v-if="!downloadLoading">Download</span>
+    </v-card>
   </v-container>
+  <div class="d-flex justify-center align-center position-relative" max-width="800">
+    <div :style="getInputModalCoords()"
+         ref="inputsCon"
+         class="position-absolute v-card--variant-flat px-1 py-1 rounded shadow-white overflow-auto"
+         v-if="inputs.length > 0">
+      <template v-for="input in inputs">
+        <component :is="input.component" :input="input" :modules="antetypeModules"/>
+      </template>
+    </div>
+    <canvas ref="canvas" class="h-screen" :style="'aspect-ratio:' + ratioWidth + '/' + ratioHeight + '; max-height: 90vh;'"/>
+  </div>
 </template>
 
 <style scoped>
-
+  .shadow-white {
+    box-shadow: 0 0 10px #FFF;
+  }
 </style>

--- a/src/components/HeroCreator/Input/Image.ts
+++ b/src/components/HeroCreator/Input/Image.ts
@@ -1,0 +1,27 @@
+import {IInputComponent} from '@/type/templateDesigner';
+import {IImageInputHandler} from '@boardmeister/antetype-conditions';
+
+const handleFiles = (e: Event, inputComponent: IInputComponent): void => {
+  const input = inputComponent.input as IImageInputHandler;
+  const files = (e.target as HTMLInputElement).files ?? [];
+  if (!files.length) {
+    return;
+  }
+  const file = files[0]!;
+  input.value = URL.createObjectURL(file);
+}
+
+export const handleImageInput = (inputComponent: IInputComponent): void => {
+  const fileInput = document.createElement('input');
+  fileInput.type = 'file';
+  fileInput.accept = 'image/*';
+  fileInput.addEventListener('change', e => {
+    handleFiles(e, inputComponent);
+    const view = inputComponent.modules.core.view;
+    void view.recalculate().then(() => {
+      view.redraw();
+    })
+  }, true);
+  fileInput.click();
+
+}

--- a/src/components/HeroCreator/Input/Multiselect.vue
+++ b/src/components/HeroCreator/Input/Multiselect.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+  import { IMultiselectOption } from '@boardmeister/antetype-conditions';
+  import {ITemplateDesignerModules} from "@/type/templateDesigner";
+  const props = defineProps(['input', 'modules'])
+  const choices = ref<string[]|null>(null);
+  const getModules = () => props.modules as ITemplateDesignerModules;
+  const getOptions = (): IMultiselectOption[] =>  props.input?.input?.options ?? [];
+  const updateChoices = (): void => {
+    for (const option of getOptions()) {
+      option.checked = choices.value!.indexOf(option.value) !== -1;
+    }
+
+    const view = getModules().core.view;
+    void view.recalculate().then(() => {
+      view.redraw();
+    })
+  }
+</script>
+
+<template>
+  <select v-model="choices" multiple @change="updateChoices" :size="getOptions().length">
+    <option v-for="option in getOptions()"
+            :value="option.value"
+            :selected="option.checked">
+      {{ option.label }}
+    </option>
+  </select>
+</template>
+
+<style scoped>
+  select[multiple] option:checked {
+    background: red linear-gradient(0deg, red 0%, red 100%);
+  }
+</style>

--- a/src/components/HeroCreator/Input/Select.ts
+++ b/src/components/HeroCreator/Input/Select.ts
@@ -1,0 +1,27 @@
+import {IInputComponent} from '@/type/templateDesigner';
+import {ISelectInputHandler} from '@boardmeister/antetype-conditions';
+
+export const handleSelectInput = (inputComponent: IInputComponent): void => {
+  const input = inputComponent.input as ISelectInputHandler
+  const {origin: {button}} = inputComponent;
+  const direction = button == 2;
+  // @TODO this is a little messy, saved for refactoring later
+  for (let i = 0; i < input.options.length; i++) {
+    const option = input.options[i];
+    if (!option.checked) {
+      continue;
+    }
+    option.checked = false;
+    if (!direction) {
+      if (i + 1 < input.options.length) input.options[i + 1].checked = true;
+      else input.options[0].checked = true;
+    } else {
+      if (i == 0) input.options.slice(-1)[0].checked = true;
+      else input.options[i - 1].checked = true;
+    }
+
+    return;
+  }
+  if (!direction) input.options[0].checked = true;
+  else input.options.slice(-1)[0].checked = true;
+}

--- a/src/components/HeroCreator/Input/Title.vue
+++ b/src/components/HeroCreator/Input/Title.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+  import { ITitleInputHandler } from '@boardmeister/antetype-conditions';
+  import { ITemplateDesignerModules } from "@/type/templateDesigner";
+
+  const props = defineProps(['input', 'modules']);
+  const input = ref<HTMLInputElement>(null);
+  const getInput = () => props.input.input as ITitleInputHandler;
+  const getModules = () => props.modules as ITemplateDesignerModules;
+  const text = ref(getInput().value);
+
+  const update = (): void => {
+    getInput().value = text.value;
+    const view = getModules().core.view;
+    void view.recalculate().then(() => {
+      view.redraw();
+    })
+  }
+
+  onMounted(() => {
+    if (input.value) {
+      setTimeout(() => {
+        input.value.focus()
+      });
+    }
+  })
+</script>
+
+<template>
+  <input ref="input" v-model="text" @input="update"
+         class="w-100 bg-white d-block rounded px-1 py-1 input-remove-default">
+</template>
+
+<style scoped>
+  .input-remove-default:focus-visible {
+    outline: none;
+  }
+</style>

--- a/src/components/MainMenu.vue
+++ b/src/components/MainMenu.vue
@@ -65,6 +65,7 @@ const buttons = ref([
   { icon: 'mdi-account-group', value: 'CampaignOverview', route: '/campaign-tracker/campaign', text: "Campaign" },
   { icon: 'mdi-magnify', value: 'Keyword', route: '/campaign-tracker/keyword', text: "Keywords" },
   { icon: 'mdi-cog-outline', value: 'settings', route: '/campaign-tracker/configuration', text: "Settings" },
+  { icon: 'mdi-account-edit', value: 'hero-creator', route: '/campaign-tracker/hero-creator', text: "Hero Creator" },
 ]);
 
 
@@ -75,7 +76,7 @@ const buttons = ref([
 
 <!--
 <template>
-  
+
   <div class="card sticky top-0 z-20">
     <v-container max-width="800" style="min-width: 360px;" class="d-none d-md-flex">
       <v-card rounded="lg" elevation="3" class="mx-auto py-4 px-6 d-flex justify-center ">
@@ -103,14 +104,14 @@ const buttons = ref([
         :key="i"
         @click="item.command()"
         :prepend-icon="item.icon"
-        > 
+        >
       </v-btn>
   </v-row>
 </v-container>
 
 
 
-    
+
   </div>
 </template>
 -->
@@ -122,11 +123,8 @@ const buttons = ref([
       <v-row justify="space-between" align="center" class="py-2" style="max-width: 800px;">
         <!-- Grupo 1: Profile e Edit -->
         <template v-for="(button, i) in buttons" :key="button.value">
-          <v-btn :icon="button.icon" @click="navigateTo(button.route)">
-          </v-btn>
-
+          <v-btn :icon="button.icon" @click="navigateTo(button.route)"/>
         </template>
-
       </v-row>
     </v-card>
   </v-container>
@@ -136,7 +134,7 @@ const buttons = ref([
       <v-row justify="space-between" align="center" class="py-2" style="max-width: 800px;">
         <!-- Grupo 1: Profile e Edit -->
         <template v-for="(button,) in buttons" :key="button.value">
-          <v-btn class="mx-1" rounded @click="navigateTo(button.route)">
+          <v-btn class="mx-1 my-1" rounded @click="navigateTo(button.route)">
             <v-icon style="font-size: 24px;">{{ button.icon }}</v-icon>
             <span> {{ button.text }} </span>
           </v-btn>
@@ -146,4 +144,3 @@ const buttons = ref([
     </v-card>
   </v-container>
 </template>
-

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -95,6 +95,17 @@ const router = createRouter({
             }
           },
         },
+        {
+          path: "/campaign-tracker/hero-creator",
+          name: "Hero Creator",
+          component: () => import("@/components/HeroCreator/HeroCreator.vue"),
+          beforeEnter(to, from, next) {
+            if (isSignedIn()) {
+              next()
+              return
+            }
+          },
+        },
         { path: "/campaign-tracker/party", redirect: "/campaign-tracker/campaign" },
         {
           path: "/campaign-tracker/campaign/:id",
@@ -228,4 +239,3 @@ const router = createRouter({
 });
 
 export default router;
-

--- a/src/service/TemplateDesigner/ActiveLayersHandler.ts
+++ b/src/service/TemplateDesigner/ActiveLayersHandler.ts
@@ -1,0 +1,136 @@
+import { ITemplateDesignerModules } from '@/type/templateDesigner';
+import { Herald } from '@boardmeister/herald';
+import { Event as CursorEvent, DownEvent, MoveEvent } from '@boardmeister/antetype-cursor';
+import { Event as CoreEvent, DrawEvent } from '@boardmeister/antetype-core';
+import { IConditionAwareDef } from '@boardmeister/antetype-conditions';
+
+export enum Event {
+  LayerActivated = 'antetype.layer.activated',
+}
+
+export type LayerActivationEvent = CustomEvent<{
+  origin: MouseEvent,
+  layer: IConditionAwareDef|null,
+}>
+
+export default class ActiveLayersHandler {
+  herald: Herald;
+  modules: ITemplateDesignerModules;
+  canvas: HTMLCanvasElement;
+  ctx: CanvasRenderingContext2D;
+  activeLayer: IConditionAwareDef|null = null;
+
+  constructor(
+    herald: Herald,
+    modules: ITemplateDesignerModules,
+    canvas: HTMLCanvasElement,
+  ) {
+    this.herald = herald;
+    this.modules = modules;
+    this.canvas = canvas;
+    this.ctx = canvas.getContext('2d')!;
+    this.register();
+  }
+
+  register(): void {
+    const unregister = this.herald.batch([
+      {
+        event: CursorEvent.MOVE,
+        subscription: this.layerChange.bind(this)
+      },
+      {
+        event: CursorEvent.DOWN,
+        subscription: this.handleInput.bind(this)
+      },
+      {
+        event: CoreEvent.CLOSE,
+        subscription: () => {
+          unregister();
+        }
+      },
+      {
+        event: CoreEvent.DRAW,
+        subscription: [
+          {
+            method: (e: CustomEvent<DrawEvent>) => {
+              const { element } = e.detail;
+              const original = this.modules.core.clone.getOriginal(element);
+              if (original !== this.activeLayer || this.modules.workspace.isExporting()) {
+                return;
+              }
+
+              const clone = this.modules.core.clone.getClone(element);
+              this.ctx.save();
+              this.ctx.shadowColor = "rgb(255, 168, 1)";
+              this.ctx.shadowBlur = Math.max(Math.min(clone.size.h, clone.size.w) * .1, 10);
+            },
+            priority: -255,
+          },
+          {
+            method: (e: CustomEvent<DrawEvent>) => {
+              const { element } = e.detail;
+              const original = this.modules.core.clone.getOriginal(element);
+              if (original !== this.activeLayer) {
+                return;
+              }
+              this.ctx.restore();
+            },
+            priority: 255,
+          },
+        ]
+      },
+    ])
+  }
+
+  async handleInput(e: CustomEvent<DownEvent>): Promise<void> {
+    const { origin } = e.detail;
+    await this.herald.dispatch(new CustomEvent(Event.LayerActivated, {
+      detail: {
+        origin,
+        layer: this.activeLayer,
+      }
+    }))
+    await this.modules.core.view.recalculate().then(() => {
+      this.modules.core.view.redraw();
+    })
+  }
+
+  hoverLayer(activeLayer: IConditionAwareDef|null): void {
+    this.activeLayer = activeLayer;
+    this.modules.core.view.redraw();
+  }
+
+  layerChange(e: CustomEvent<MoveEvent>): void {
+    const { target: { hover: { deep, layer }} } = e.detail;
+    if (deep?.type === 'selection') {
+      return;
+    }
+
+    const activeLayer = deep && this.#hasInputs(deep, layer);
+    if (this.activeLayer === activeLayer) {
+      return;
+    }
+
+    if (activeLayer) {
+      this.hoverLayer(this.modules.core.clone.getOriginal(activeLayer))
+      this.canvas.style.cursor = 'pointer';
+    } else {
+      this.hoverLayer(null)
+      this.activeLayer = null;
+      this.modules.core.view.redraw();
+      this.canvas.style.cursor = 'default';
+    }
+  }
+
+  #hasInputs(layer: IConditionAwareDef, stopParent: IConditionAwareDef): false|IConditionAwareDef {
+    if (layer.conditions?.inputs && layer.conditions.inputs.length > 0) {
+      return layer;
+    }
+
+    if (layer === stopParent || !layer.hierarchy?.parent) {
+      return false;
+    }
+
+    return this.#hasInputs(layer.hierarchy?.parent, stopParent);
+  }
+}

--- a/src/type/templateDesigner.d.ts
+++ b/src/type/templateDesigner.d.ts
@@ -1,0 +1,22 @@
+import Conditions, { IInputHandler, IConditionAwareDef } from '@boardmeister/antetype-conditions';
+import { Modules } from "@boardmeister/antetype-core"
+import Illustrator from '@boardmeister/antetype-illustrator';
+import Workspace from '@boardmeister/antetype-workspace';
+import Transform from '@boardmeister/antetype-transform';
+import Cursor from '@boardmeister/antetype-cursor';
+
+export interface ITemplateDesignerModules extends Modules {
+  conditions: Conditions;
+  illustrator: Illustrator;
+  workspace: Workspace;
+  transform: Transform;
+  cursor: Cursor;
+}
+
+export interface IInputComponent {
+  component: object;
+  origin: MouseEvent,
+  input: IInputHandler,
+  layer: IConditionAwareDef,
+  modules: ITemplateDesignerModules,
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,8 +28,9 @@
   "include": [
     "src/**/*",
     "src/**/*.vue",
-    "src/typed-router.d.ts"
-, "e2e"  ],
+    "src/typed-router.d.ts",
+    "e2e"
+  ],
   "exclude": ["dist", "node_modules", "cypress"],
   "references": [{ "path": "./tsconfig.node.json" }],
 }


### PR DESCRIPTION
Pull request for new feature: Hero Creator.

This PR uses few private repositories (for now, I still have to sit down and add them to node repository :sweat: ):
- the native implementation (newest commit) uses:
  - @boardmeister/antetype-core
  - @boardmeister/antetype-conditions
  - @boardmeister/antetype-illustrator
  - @boardmeister/antetype-workspace
  - @boardmeister/antetype-transform
  - @boardmeister/antetype-cursor
  - @boardmeister/herald
and is missing config file fore hero definition  (path to the config is defined using dotenv files)
- integration with Board Meister uses additionally (previous commit):
  - @boardmeister/guard 
  - @boardmeister/diemut 
  - @boardmeister/treasurer 
  - @boardmeister/marshal 
  - @boardmeister/minstrel
 
Here is screenshot for reference how the implementation looks like (as it is currently impossible to run this feature without access to config file and priv repos):
![Screenshot 2025-04-02 at 09-51-35 Chronicles of Drunagor - Companion App](https://github.com/user-attachments/assets/1d4ddfd8-d659-4fbb-a8ba-88ec02e50d8e)

Few notes:
- When setting up dotenv files, the current configuration didn't want to load `.env` variables to the space but `.env.local` worked without issues - something to address later
- This PR is made of two possible solutions:
  - [Hero creator Board Meister intergation](https://github.com/CGS-WEBSITES/drunagor_app_front/commit/e0d880998a0b2dcebb106639f365e3ec0dfca85c) - how the integration with SaaS Board Meister would look like
  - [Native intergation](https://github.com/CGS-WEBSITES/drunagor_app_front/commit/e15d6c7740f3686b0ae0a354ba86374257d80a96) - how we can achieve native integration