### PR TITLE
feat(events): add loading spinner and enforce min-height on event lists

### DIFF
--- a/src/components/RetailEvents.vue
+++ b/src/components/RetailEvents.vue
@@ -1,7 +1,9 @@
 <template>
   <v-row justify="center">
     <v-col cols="12" class="text-center">
-      <h1 class="cinzel-text font-weight-black pt-15 pb-4 justify-center text-center text-h2">
+      <h1
+        class="cinzel-text font-weight-black pt-15 pb-4 justify-center text-center text-h2"
+      >
         EVENTS
       </h1>
     </v-col>
@@ -11,7 +13,13 @@
     <v-card class="pb-12" min-height="500px" color="#151515">
       <v-row no-gutters>
         <v-col cols="12">
-          <v-tabs class="EventsTabs mb-3" v-model="activeTab" fixed-tabs align-tabs="center" color="white">
+          <v-tabs
+            class="EventsTabs mb-3"
+            v-model="activeTab"
+            fixed-tabs
+            align-tabs="center"
+            color="white"
+          >
             <v-tab class="text-h5" :value="1">ALL EVENTS</v-tab>
             <v-tab class="text-h5" :value="2">MY EVENTS</v-tab>
           </v-tabs>
@@ -19,59 +27,105 @@
       </v-row>
 
       <div v-if="activeTab === 1">
-        <v-row>
-          <v-col class="py-2 pl-1 pr-1" cols="12" md="6" v-for="(event, index) in sortedEvents" :key="index">
-            <v-card color="terciary" class="pt-0 event-card" @click="openDialog(event)">
-              <v-row no-gutters>
-                <v-col cols="4" sm="2">
-                  <div class="text-center ml-3" style="width: 70px; color: black">
-                    <p class="pt-3 text-caption font-weight-bold">
-                      {{
-                        new Date(event.event_date)
-                          .toLocaleDateString("en-US", {
-                            month: "short",
-                          })
-                          .toUpperCase()
-                      }}
+        <div v-if="loading" class="d-flex justify-center my-8">
+          <v-progress-circular indeterminate size="48" color="primary" />
+        </div>
+        <div v-else class="list-container">
+          <v-row>
+            <v-col
+              class="py-2 pl-1 pr-1"
+              cols="12"
+              md="6"
+              v-for="(event, index) in sortedEvents"
+              :key="index"
+            >
+              <v-card
+                color="terciary"
+                class="pt-0 event-card"
+                @click="openDialog(event)"
+              >
+                <v-row no-gutters>
+                  <v-col cols="4" sm="2">
+                    <div
+                      class="text-center ml-3"
+                      style="width: 70px; color: black"
+                    >
+                      <p class="pt-3 text-caption font-weight-bold">
+                        {{
+                          new Date(event.event_date)
+                            .toLocaleDateString("en-US", {
+                              month: "short",
+                            })
+                            .toUpperCase()
+                        }}
+                      </p>
+                      <p
+                        color="primary"
+                        class="cinzel-text text-h3 font-weight-bold"
+                      >
+                        {{
+                          String(event.event_date).split("T")[0].split("-")[2]
+                        }}
+                      </p>
+                      <p class="text-caption font-weight-bold">
+                        {{
+                          new Date(event.event_date).toLocaleTimeString(
+                            "en-US",
+                            {
+                              hour: "2-digit",
+                              minute: "2-digit",
+                              hour12: true,
+                            },
+                          )
+                        }}
+                      </p>
+                    </div>
+                  </v-col>
+                  <v-col cols="8" sm="10" class="pt-2">
+                    <h3 class="pb-1">
+                      <v-icon class="pr-1" size="small" color="black"
+                        >mdi-chess-rook</v-icon
+                      >
+                      {{ event.store_name }}
+                    </h3>
+                    <p class="text-caption text-truncate">
+                      <v-icon color="red">mdi-map-marker</v-icon>
+                      {{ event.address }}
                     </p>
-                    <p color="primary" class="cinzel-text text-h3 font-weight-bold">
-                      {{ String(event.event_date).split('T')[0].split('-')[2] }}
+                    <p class="text-caption">
+                      <v-icon color="red">mdi-sword-cross</v-icon> Scenario:
+                      {{ event.scenario }}
                     </p>
-                    <p class="text-caption font-weight-bold">
-                      {{ new Date(event.event_date).toLocaleTimeString('en-US', {
-                        hour: '2-digit', minute: '2-digit',
-                        hour12: true
-                      }) }}
+                    <p
+                      class="text-caption ml-3"
+                      v-if="event.rewards && event.rewards.length"
+                    >
+                      <v-row class="d-flex align-center rewards-container">
+                        <v-icon class="mr-1" color="red"
+                          >mdi-star-circle</v-icon
+                        >
+                        Rewards:
+                        <v-col
+                          cols="auto"
+                          v-for="(reward, index) in event.rewards"
+                          :key="index"
+                        >
+                          <v-img
+                            :src="reward.image"
+                            height="20"
+                            width="20"
+                            contain
+                            class="reward-icon"
+                          ></v-img>
+                        </v-col>
+                      </v-row>
                     </p>
-                  </div>
-                </v-col>
-                <v-col cols="8" sm="10" class="pt-2">
-                  <h3 class="pb-1">
-                    <v-icon class="pr-1" size="small" color="black">mdi-chess-rook</v-icon>
-                    {{ event.store_name }}
-                  </h3>
-                  <p class="text-caption text-truncate">
-                    <v-icon color="red">mdi-map-marker</v-icon>
-                    {{ event.address }}
-                  </p>
-                  <p class="text-caption">
-                    <v-icon color="red">mdi-sword-cross</v-icon> Scenario:
-                    {{ event.scenario }}
-                  </p>
-                  <p class="text-caption ml-3" v-if="event.rewards && event.rewards.length">
-                    <v-row class="d-flex align-center rewards-container">
-                      <v-icon class="mr-1" color="red">mdi-star-circle</v-icon>
-                      Rewards:
-                      <v-col cols="auto" v-for="(reward, index) in event.rewards" :key="index">
-                        <v-img :src="reward.image" height="20" width="20" contain class="reward-icon"></v-img>
-                      </v-col>
-                    </v-row>
-                  </p>
-                </v-col>
-              </v-row>
-            </v-card>
-          </v-col>
-        </v-row>
+                  </v-col>
+                </v-row>
+              </v-card>
+            </v-col>
+          </v-row>
+        </div>
 
         <!-- Diálogo para visualização do evento -->
         <v-dialog v-model="dialog" max-width="600" min-height="410">
@@ -80,17 +134,24 @@
               <v-btn color="red" @click="dialog = false">X</v-btn>
             </v-card-actions>
             <v-card-text>
-              <p><v-icon>mdi-seat</v-icon> Disponible Seats: {{ selectedEvent?.seats_number }}</p>
-              <p><v-icon>mdi-sword-cross</v-icon> Scenario: {{ selectedEvent?.scenario }}</p>
+              <p>
+                <v-icon>mdi-seat</v-icon> Disponible Seats:
+                {{ selectedEvent?.seats_number }}
+              </p>
+              <p>
+                <v-icon>mdi-sword-cross</v-icon> Scenario:
+                {{ selectedEvent?.scenario }}
+              </p>
               <p class="text-end scheduled-box">
-                Sheduled for: {{
-                  new Date(selectedEvent?.event_date).toLocaleString('en-US', {
-                    month: '2-digit',
-                    day: '2-digit',
-                    year: 'numeric',
-                    hour: '2-digit',
-                    minute: '2-digit',
-                    hour12: true
+                Sheduled for:
+                {{
+                  new Date(selectedEvent?.event_date).toLocaleString("en-US", {
+                    month: "2-digit",
+                    day: "2-digit",
+                    year: "numeric",
+                    hour: "2-digit",
+                    minute: "2-digit",
+                    hour12: true,
                   })
                 }}
               </p>
@@ -98,9 +159,14 @@
             <v-card color="primary" min-height="130px" class="mr-4 event-card">
               <v-row no-gutters>
                 <v-col cols="3" lg="3">
-                  <v-img :src="selectedEvent?.picture_hash
-                    ? `https://druna-assets.s3.us-east-2.amazonaws.com/${selectedEvent.picture_hash}`
-                    : 'https://s3.us-east-2.amazonaws.com/assets.drunagor.app/Profile/store.png'" class="event-img" />
+                  <v-img
+                    :src="
+                      selectedEvent?.picture_hash
+                        ? `https://druna-assets.s3.us-east-2.amazonaws.com/${selectedEvent.picture_hash}`
+                        : 'https://s3.us-east-2.amazonaws.com/assets.drunagor.app/Profile/store.png'
+                    "
+                    class="event-img"
+                  />
                 </v-col>
                 <v-col cols="9" class="pa-2">
                   <h3 class="text-subtitle-1 font-weight-bold">
@@ -117,42 +183,187 @@
             <v-card-text>
               <h3 class="text-h6 font-weight-bold">REWARDS:</h3>
 
-              <v-row v-if="eventRewards.length" v-for="(reward, index) in eventRewards" :key="index"
-                class="align-center my-2">
+              <v-row
+                v-if="eventRewards.length"
+                v-for="(reward, index) in eventRewards"
+                :key="index"
+                class="align-center my-2"
+              >
                 <v-col cols="3" md="2">
                   <v-avatar size="60">
-                    <v-img :src="`https://druna-assets.s3.us-east-2.amazonaws.com/${reward.picture_hash}`" />
+                    <v-img
+                      :src="`https://druna-assets.s3.us-east-2.amazonaws.com/${reward.picture_hash}`"
+                    />
                   </v-avatar>
                 </v-col>
                 <v-col cols="9" md="10">
-                  <h4 class="text-subtitle-1 font-weight-bold">{{ reward.name }}</h4>
+                  <h4 class="text-subtitle-1 font-weight-bold">
+                    {{ reward.name }}
+                  </h4>
                 </v-col>
               </v-row>
 
-              <p v-else class="text-caption">No rewards linked to this event.</p>
+              <p v-else class="text-caption">
+                No rewards linked to this event.
+              </p>
             </v-card-text>
-            <v-row class="mt-2 ml-0">
-            </v-row>
+            <v-row class="mt-2 ml-0"> </v-row>
           </v-card>
         </v-dialog>
       </div>
 
       <div v-if="activeTab === 2">
-        <v-row class="CreateNew align-center bg-gray text-white">
-          <v-col cols="2"></v-col>
-          <v-col cols="3">
-            <v-btn variant="text" class="sort-btn" @click="openCreateEventDialog">
-              <v-icon>mdi-plus-box-outline</v-icon>
-              Create New
-            </v-btn>
-          </v-col>
-          <v-col cols="4">
-            <v-btn variant="text" class="sort-btn" @click="">PAST</v-btn>
-          </v-col>
-          <v-col cols="3">
-            <v-btn variant="text" class="sort-btn" @click="">LIVE</v-btn>
-          </v-col>
-        </v-row>
+        <div v-if="loading" class="d-flex justify-center my-8">
+          <v-progress-circular indeterminate size="48" color="primary" />
+        </div>
+        <div v-else class="list-container">
+          <v-row class="CreateNew align-center bg-gray text-white">
+            <v-col cols="2"></v-col>
+            <v-col cols="3">
+              <v-btn
+                variant="text"
+                class="sort-btn"
+                @click="openCreateEventDialog"
+              >
+                <v-icon>mdi-plus-box-outline</v-icon>
+                Create New
+              </v-btn>
+            </v-col>
+            <v-col cols="4">
+              <v-btn variant="text" class="sort-btn" @click="">PAST</v-btn>
+            </v-col>
+            <v-col cols="3">
+              <v-btn variant="text" class="sort-btn" @click="">LIVE</v-btn>
+            </v-col>
+          </v-row>
+
+          <v-row>
+            <v-col
+              class="py-2 pl-1 pr-1"
+              cols="12"
+              md="6"
+              v-for="(event, index) in userCreatedEvents"
+              :key="index"
+            >
+              <v-card
+                color="white"
+                max-height="120"
+                class="pt-0 pl-0 pb-0 event-card"
+                @click="openEditDialog(event)"
+              >
+                <v-row no-gutters>
+                  <v-col cols="auto" class="redbutton pt-13 pl-3">
+                    <v-btn
+                      color="#AB2929"
+                      icon
+                      class="delete-btn"
+                      @click.stop="deleteEvent(event.events_pk)"
+                    >
+                      <v-icon>mdi-close</v-icon>
+                    </v-btn>
+                  </v-col>
+                  <v-col cols="8" class="pt-6 pr-3">
+                    <v-row no-gutters>
+                      <v-col cols="4" sm="2">
+                        <div
+                          class="text-center ml-2 pr-3"
+                          style="width: 74px; color: black"
+                        >
+                          <p class="pt-3 text-caption font-weight-bold">
+                            {{
+                              new Date(event.event_date)
+                                .toLocaleDateString("en-US", {
+                                  month: "short",
+                                })
+                                .toUpperCase()
+                            }}
+                          </p>
+                          <p
+                            color="primary"
+                            class="cinzel-text text-h3 font-weight-bold"
+                          >
+                            {{
+                              String(event.event_date)
+                                .split("T")[0]
+                                .split("-")[2]
+                            }}
+                          </p>
+                          <p class="text-caption font-weight-bold">
+                            {{
+                              new Date(event.event_date).toLocaleTimeString(
+                                "en-US",
+                                {
+                                  hour: "2-digit",
+                                  minute: "2-digit",
+                                  hour12: true,
+                                },
+                              )
+                            }}
+                            <!-- {{ event.ampm }} -->
+                          </p>
+                        </div>
+                      </v-col>
+
+                      <v-col cols="8" sm="10" class="pt-2 pl-5">
+                        <h3 class="pb-1 text-truncate">
+                          <v-icon class="pr-1" size="small" color="black"
+                            >mdi-chess-rook</v-icon
+                          >
+                          {{ event.store_name }}
+                        </h3>
+
+                        <p class="text-caption text-truncate">
+                          <v-icon color="red">mdi-map-marker</v-icon>
+                          {{ event.address }}
+                        </p>
+
+                        <p class="text-caption" v-if="event.scenario">
+                          <v-icon color="red">mdi-sword-cross</v-icon>
+                          Scenario: {{ event.scenario }}
+                        </p>
+
+                        <p
+                          class="text-caption ml-3"
+                          v-if="event.rewards && event.rewards.length"
+                        >
+                          <v-row class="d-flex align-center rewards-container">
+                            <v-icon class="mr-1" color="red"
+                              >mdi-star-circle</v-icon
+                            >
+                            Rewards:
+                            <v-col
+                              cols="auto"
+                              v-for="(reward, index) in event.rewards"
+                              :key="index"
+                            >
+                              <v-img
+                                :src="reward.image"
+                                height="20"
+                                width="20"
+                                contain
+                                class="reward-icon"
+                              ></v-img>
+                            </v-col>
+                          </v-row>
+                        </p>
+                      </v-col>
+                    </v-row>
+                  </v-col>
+                </v-row>
+                <v-col cols="auto" class="editbutton pt-13 pl-3">
+                  <v-btn
+                    color="white"
+                    icon
+                    class="delete-btn"
+                    @click.stop="openEditDialog(event, true)"
+                  >
+                    <v-icon>mdi mdi-pencil</v-icon>
+                  </v-btn>
+                </v-col>
+              </v-card>
+            </v-col>
+          </v-row>
+        </div>
         <v-dialog v-model="createEventDialog" max-width="1280">
           <v-btn icon class="close-btn" @click="createEventDialog = false">
             <v-icon>mdi-close</v-icon>
@@ -161,8 +372,12 @@
             <v-card-text>
               <v-row>
                 <v-col cols="12" md="12">
-                  <v-select v-model="newEvent.store" :items="stores.map(store => store.name)" label="STORE"
-                    variant="outlined" />
+                  <v-select
+                    v-model="newEvent.store"
+                    :items="stores.map((store) => store.name)"
+                    label="STORE"
+                    variant="outlined"
+                  />
                 </v-col>
                 <!-- Descrição -->
                 <!-- <v-col cols="12">
@@ -171,43 +386,90 @@
                 </v-col> -->
                 <!-- Assentos + Data/Hora -->
                 <v-col cols="12" md="6">
-                  <v-select v-model="newEvent.seats" :items="[1, 2, 3, 4]" label="SEATS" variant="outlined"></v-select>
+                  <v-select
+                    v-model="newEvent.seats"
+                    :items="[1, 2, 3, 4]"
+                    label="SEATS"
+                    variant="outlined"
+                  ></v-select>
                 </v-col>
                 <v-col cols="6" md="6">
-                  <v-select v-model="newEvent.scenario" :items="sceneries" item-title="name" item-value="sceneries_pk"
-                    label="SCENARIO" variant="outlined"></v-select>
+                  <v-select
+                    v-model="newEvent.scenario"
+                    :items="sceneries"
+                    item-title="name"
+                    item-value="sceneries_pk"
+                    label="SCENARIO"
+                    variant="outlined"
+                  ></v-select>
                 </v-col>
                 <v-col cols="6" md="3">
-                  <v-text-field v-model="newEvent.hour" label="TIME" variant="outlined" placeholder="HH:MM"
-                    maxlength="5" @input="handleTimeInput"></v-text-field>
+                  <v-text-field
+                    v-model="newEvent.hour"
+                    label="TIME"
+                    variant="outlined"
+                    placeholder="HH:MM"
+                    maxlength="5"
+                    @input="handleTimeInput"
+                  ></v-text-field>
                 </v-col>
                 <v-col cols="6" md="2">
-                  <v-select v-model="newEvent.ampm" :items="['AM', 'PM']" label="AM/PM" variant="outlined"></v-select>
+                  <v-select
+                    v-model="newEvent.ampm"
+                    :items="['AM', 'PM']"
+                    label="AM/PM"
+                    variant="outlined"
+                  ></v-select>
                 </v-col>
                 <v-col cols="12" md="2" class="d-flex align-center">
-                  <v-text-field v-model="newEvent.date" label="DATE" type="date" variant="outlined" class="date-input"
-                    :min="today" :max="oneYearFromTodayISO" :rules="dateRules"></v-text-field>
+                  <v-text-field
+                    v-model="newEvent.date"
+                    label="DATE"
+                    type="date"
+                    variant="outlined"
+                    class="date-input"
+                    :min="today"
+                    :max="oneYearFromTodayISO"
+                    :rules="dateRules"
+                  ></v-text-field>
                 </v-col>
                 <!-- Recompensas -->
                 <v-col cols="12">
                   <p class="pb-3 font-weight-bold">REWARDS</p>
-                  <v-autocomplete v-model="selectedRewards" :items="allRewards" item-title="name"
-                    item-value="rewards_pk" label="Select Rewards" multiple return-object>
-
+                  <v-autocomplete
+                    v-model="selectedRewards"
+                    :items="allRewards"
+                    item-title="name"
+                    item-value="rewards_pk"
+                    label="Select Rewards"
+                    multiple
+                    return-object
+                  >
                     <template #item="{ item, props }">
                       <v-list-item v-bind="props">
                         <template #prepend>
                           <v-avatar size="32">
-                            <v-img :src="`https://druna-assets.s3.us-east-2.amazonaws.com/${item.raw.picture_hash}`" />
+                            <v-img
+                              :src="`https://druna-assets.s3.us-east-2.amazonaws.com/${item.raw.picture_hash}`"
+                            />
                           </v-avatar>
                         </template>
-                        <v-list-item-title>{{ item.raw.name }}</v-list-item-title>
+                        <v-list-item-title>{{
+                          item.raw.name
+                        }}</v-list-item-title>
                       </v-list-item>
                     </template>
                     <template #selection="{ item, index }">
-                      <v-chip size="small" class="ma-1" closable @click:close="selectedRewards.splice(index, 1)">
+                      <v-chip
+                        size="small"
+                        class="ma-1"
+                        closable
+                        @click:close="selectedRewards.splice(index, 1)"
+                      >
                         <v-avatar start size="24">
-                          <v-img :src="`https://druna-assets.s3.us-east-2.amazonaws.com/${item.raw.picture_hash}`" />
+                          <v-img
+                            :src="`https://druna-assets.s3.us-east-2.amazonaws.com/${item.raw.picture_hash}`"
+                          />
                         </v-avatar>
                         {{ item.raw.name }}
                       </v-chip>
@@ -215,145 +477,143 @@
                   </v-autocomplete>
                 </v-col>
                 <v-col cols="12">
-                  <v-btn block color="secundary" class="launch-btn mt-12" @click="addEvent">LAUNCH EVENT</v-btn>
+                  <v-btn
+                    block
+                    color="secundary"
+                    class="launch-btn mt-12"
+                    @click="addEvent"
+                    >LAUNCH EVENT</v-btn
+                  >
                 </v-col>
               </v-row>
             </v-card-text>
           </v-card>
         </v-dialog>
-        <v-row>
-          <v-col class="py-2 pl-1 pr-1" cols="12" md="6" v-for="(event, index) in userCreatedEvents" :key="index">
-            <v-card color="white" max-height="120" class="pt-0 pl-0 pb-0 event-card" @click="openEditDialog(event)">
-              <v-row no-gutters>
-                <v-col cols="auto" class="redbutton pt-13 pl-3">
-                  <v-btn color="#AB2929" icon class="delete-btn" @click.stop="deleteEvent(event.events_pk)">
-                    <v-icon>mdi-close</v-icon>
-                  </v-btn>
-                </v-col>
-                <v-col cols="8" class="pt-6 pr-3">
-                  <v-row no-gutters>
-                    <v-col cols="4" sm="2">
-                      <div class="text-center ml-2 pr-3" style="width: 74px; color: black">
-                        <p class="pt-3 text-caption font-weight-bold">
-                          {{
-                            new Date(event.event_date)
-                              .toLocaleDateString("en-US", {
-                                month: "short",
-                              })
-                              .toUpperCase()
-                          }}
-                        </p>
-                        <p color="primary" class="cinzel-text text-h3 font-weight-bold">
-                          {{
-                            String(event.event_date).split("T")[0].split("-")[2]
-                          }}
-                        </p>
-                        <p class="text-caption font-weight-bold">
-                          {{ new Date(event.event_date).toLocaleTimeString('en-US', {
-                            hour: '2-digit', minute:
-                              '2-digit', hour12: true
-                          }) }}
-                          <!-- {{ event.ampm }} -->
-                        </p>
-                      </div>
-                    </v-col>
-
-                    <v-col cols="8" sm="10" class="pt-2 pl-5">
-                      <h3 class="pb-1 text-truncate">
-                        <v-icon class="pr-1" size="small" color="black">mdi-chess-rook</v-icon>
-                        {{ event.store_name }}
-                      </h3>
-
-                      <p class="text-caption text-truncate">
-                        <v-icon color="red">mdi-map-marker</v-icon>
-                        {{ event.address }}
-                      </p>
-
-                      <p class="text-caption" v-if="event.scenario">
-                        <v-icon color="red">mdi-sword-cross</v-icon>
-                        Scenario: {{ event.scenario }}
-                      </p>
-
-                      <p class="text-caption ml-3" v-if="event.rewards && event.rewards.length">
-                        <v-row class="d-flex align-center rewards-container">
-                          <v-icon class="mr-1" color="red">mdi-star-circle</v-icon>
-                          Rewards:
-                          <v-col cols="auto" v-for="(reward, index) in event.rewards" :key="index">
-                            <v-img :src="reward.image" height="20" width="20" contain class="reward-icon"></v-img>
-                          </v-col>
-                        </v-row>
-                      </p>
-                    </v-col>
-                  </v-row>
-                </v-col>
-              </v-row>
-              <v-col cols="auto" class="editbutton pt-13 pl-3">
-                <v-btn color="white" icon class="delete-btn" @click.stop="openEditDialog(event, true)">
-                  <v-icon>mdi mdi-pencil</v-icon>
-                </v-btn>
-              </v-col>
-            </v-card>
-          </v-col>
-        </v-row>
         <!-- Diálogo de Edição / Visualização com lista de Players Interested -->
-        <v-dialog v-model="editEventDialog" scroll-target="#app" max-width="800">
+        <v-dialog
+          v-model="editEventDialog"
+          scroll-target="#app"
+          max-width="800"
+        >
           <v-card class="dark-background">
             <v-card-text>
               <v-row>
                 <v-col cols="6" md="6" v-if="isEditable">
-                  <v-select v-model="editableEvent.seats_number" :items="[1, 2, 3, 4]" label="SEATS"
-                    variant="outlined"></v-select>
+                  <v-select
+                    v-model="editableEvent.seats_number"
+                    :items="[1, 2, 3, 4]"
+                    label="SEATS"
+                    variant="outlined"
+                  ></v-select>
                 </v-col>
                 <v-col cols="6" md="6" v-if="isEditable">
-
-                  <v-select v-model="editableEvent.sceneries" :items="sceneries" item-title="name"
-                    item-value="sceneries_pk" label="SCENARIO" variant="outlined" :key="sceneries.length"></v-select>
+                  <v-select
+                    v-model="editableEvent.sceneries"
+                    :items="sceneries"
+                    item-title="name"
+                    item-value="sceneries_pk"
+                    label="SCENARIO"
+                    variant="outlined"
+                    :key="sceneries.length"
+                  ></v-select>
                 </v-col>
                 <v-col cols="6" md="3" v-if="isEditable">
-                  <v-text-field v-model="editableEvent.hour" label="TIME" variant="outlined" placeholder="HH:MM"
-                    maxlength="5" @blur="validateTime"></v-text-field>
+                  <v-text-field
+                    v-model="editableEvent.hour"
+                    label="TIME"
+                    variant="outlined"
+                    placeholder="HH:MM"
+                    maxlength="5"
+                    @blur="validateTime"
+                  ></v-text-field>
                 </v-col>
                 <v-col cols="6" md="2" v-if="isEditable">
-                  <v-select v-model="editableEvent.ampm" :items="['AM', 'PM']" label="AM/PM"
-                    variant="outlined"></v-select>
+                  <v-select
+                    v-model="editableEvent.ampm"
+                    :items="['AM', 'PM']"
+                    label="AM/PM"
+                    variant="outlined"
+                  ></v-select>
                 </v-col>
-                <v-col cols="12" md="2" class="d-flex align-center" v-if="isEditable">
-                  <v-text-field v-model="editableEvent.date" label="DATE" type="date" variant="outlined"
-                    class="date-input" :min="today" :max="oneYearFromTodayISO" :rules="dateRules"></v-text-field>
+                <v-col
+                  cols="12"
+                  md="2"
+                  class="d-flex align-center"
+                  v-if="isEditable"
+                >
+                  <v-text-field
+                    v-model="editableEvent.date"
+                    label="DATE"
+                    type="date"
+                    variant="outlined"
+                    class="date-input"
+                    :min="today"
+                    :max="oneYearFromTodayISO"
+                    :rules="dateRules"
+                  ></v-text-field>
                 </v-col>
                 <v-col cols="12" v-if="isEditable">
                   <p class="pb-3 font-weight-bold">REWARDS</p>
-                  <v-autocomplete v-model="editableEvent.rewards" :items="availableRewards" item-title="name"
-                    item-value="rewards_pk" label="Select Rewards" multiple chips
-                    return-object={false}></v-autocomplete>
+                  <v-autocomplete
+                    v-model="editableEvent.rewards"
+                    :items="availableRewards"
+                    item-title="name"
+                    item-value="rewards_pk"
+                    label="Select Rewards"
+                    multiple
+                    chips
+                    return-object="{false}"
+                  ></v-autocomplete>
                 </v-col>
                 <!-- Se não estiver em modo edição, exibe a lista de Players Interested -->
-                <v-col cols="12" class="d-flex align-end flex-column" v-if="!isEditable">
+                <v-col
+                  cols="12"
+                  class="d-flex align-end flex-column"
+                  v-if="!isEditable"
+                >
                   <v-col class="d-flex align-center flex-column">
                     <v-card color="surface" class="ml-5">
                       <v-card-text>
-                        <p><v-icon>mdi-seat</v-icon> Disponible Seats: {{ selectedEvent?.seats_number }}</p>
-                        <p><v-icon>mdi-sword-cross</v-icon> Scenario: {{ selectedEvent?.scenario }}</p>
+                        <p>
+                          <v-icon>mdi-seat</v-icon> Disponible Seats:
+                          {{ selectedEvent?.seats_number }}
+                        </p>
+                        <p>
+                          <v-icon>mdi-sword-cross</v-icon> Scenario:
+                          {{ selectedEvent?.scenario }}
+                        </p>
                         <p class="text-end scheduled-box">
-                          Sheduled for: {{
-                            new Date(selectedEvent?.event_date).toLocaleString('en-US', {
-                              month: '2-digit',
-                              day: '2-digit',
-                              year: 'numeric',
-                              hour: '2-digit',
-                              minute: '2-digit',
-                              hour12: true
-                            })
+                          Sheduled for:
+                          {{
+                            new Date(selectedEvent?.event_date).toLocaleString(
+                              "en-US",
+                              {
+                                month: "2-digit",
+                                day: "2-digit",
+                                year: "numeric",
+                                hour: "2-digit",
+                                minute: "2-digit",
+                                hour12: true,
+                              },
+                            )
                           }}
                         </p>
                       </v-card-text>
-                      <v-card color="primary" min-height="130px" class="mr-4 event-card">
+                      <v-card
+                        color="primary"
+                        min-height="130px"
+                        class="mr-4 event-card"
+                      >
                         <v-row no-gutters>
                           <v-col cols="3" lg="3">
-                            <v-img :src="selectedEvent?.picture_hash
-                              ? `https://druna-assets.s3.us-east-2.amazonaws.com/${selectedEvent.picture_hash}`
-                              : 'https://s3.us-east-2.amazonaws.com/assets.drunagor.app/Profile/store.png'"
-                              class="event-img" />
+                            <v-img
+                              :src="
+                                selectedEvent?.picture_hash
+                                  ? `https://druna-assets.s3.us-east-2.amazonaws.com/${selectedEvent.picture_hash}`
+                                  : 'https://s3.us-east-2.amazonaws.com/assets.drunagor.app/Profile/store.png'
+                              "
+                              class="event-img"
+                            />
                           </v-col>
                           <v-col cols="9" class="pa-2">
                             <h3 class="text-subtitle-1 font-weight-bold">
@@ -370,110 +630,188 @@
                       <v-card-text>
                         <h3 class="text-h6 font-weight-bold mb-1">REWARDS:</h3>
 
-                        <v-row v-if="eventRewards.length" v-for="(reward, index) in eventRewards" :key="index"
-                          class="align-center ">
+                        <v-row
+                          v-if="eventRewards.length"
+                          v-for="(reward, index) in eventRewards"
+                          :key="index"
+                          class="align-center"
+                        >
                           <v-col cols="3" md="2">
                             <v-avatar>
-                              <v-img :src="`https://druna-assets.s3.us-east-2.amazonaws.com/${reward.picture_hash}`" />
+                              <v-img
+                                :src="`https://druna-assets.s3.us-east-2.amazonaws.com/${reward.picture_hash}`"
+                              />
                             </v-avatar>
                           </v-col>
                           <v-col cols="9" md="10">
-                            <h4 class="text-subtitle-1 font-weight-bold">{{ reward.name }}</h4>
+                            <h4 class="text-subtitle-1 font-weight-bold">
+                              {{ reward.name }}
+                            </h4>
                           </v-col>
                         </v-row>
 
-                        <p v-else class="text-caption">No rewards linked to this event.</p>
+                        <p v-else class="text-caption">
+                          No rewards linked to this event.
+                        </p>
                       </v-card-text>
-                      <br>
-                      <v-btn block color="blue" size="small" variant="flat" class="mt-2"
-                        @click="shareEvent(selectedEvent?.events_pk)">
+                      <br />
+                      <v-btn
+                        block
+                        color="blue"
+                        size="small"
+                        variant="flat"
+                        class="mt-2"
+                        @click="shareEvent(selectedEvent?.events_pk)"
+                      >
                         <v-icon start>mdi-share-variant</v-icon>
                         Share Event
                       </v-btn>
-                      
-                       <v-dialog v-model="showDialog" width="400">
+
+                      <v-dialog v-model="showDialog" width="400">
                         <v-card>
-                          <v-card-title class="text-h6">Share Event</v-card-title>
+                          <v-card-title class="text-h6"
+                            >Share Event</v-card-title
+                          >
                           <v-card-text>
-                            <v-text-field v-model="sharedLink" label="Event Link" readonly density="compact"
-                              hide-details></v-text-field>
+                            <v-text-field
+                              v-model="sharedLink"
+                              label="Event Link"
+                              readonly
+                              density="compact"
+                              hide-details
+                            ></v-text-field>
                           </v-card-text>
                           <v-card-actions>
                             <v-spacer></v-spacer>
-                            <v-btn color="success" size="small" @click="copyLink(sharedLink)">
+                            <v-btn
+                              color="success"
+                              size="small"
+                              @click="copyLink(sharedLink)"
+                            >
                               Copy Link
                             </v-btn>
-                            <v-btn color="grey" size="small" @click="showDialog = false">
+                            <v-btn
+                              color="grey"
+                              size="small"
+                              @click="showDialog = false"
+                            >
                               Close
                             </v-btn>
                           </v-card-actions>
                         </v-card>
                       </v-dialog>
-
-
-
                     </v-card>
                   </v-col>
                   <v-col>
                     <p class="pb-3 font-weight-bold">PLAYERS INTERESTED</p>
                   </v-col>
                   <v-row>
-                    <v-col cols="12" v-for="(player, index) in paginatedPlayers" :key="player.users_pk" class="pa-1">
+                    <v-col
+                      cols="12"
+                      v-for="(player, index) in paginatedPlayers"
+                      :key="player.users_pk"
+                      class="pa-1"
+                    >
                       <v-card class="pa-1 mb-3" rounded="lg" elevation="10">
-
-                        <v-row no-gutters> <!-- remove espaço interno entre colunas -->
+                        <v-row no-gutters>
+                          <!-- remove espaço interno entre colunas -->
                           <!-- Imagem do jogador -->
                           <v-col cols="4" lg="1" class="d-flex">
-                            <v-img :src="player.picture_hash
-                              ? `https://druna-assets.s3.us-east-2.amazonaws.com/Profile/${player.picture_hash}`
-                              : 'https://s3.us-east-2.amazonaws.com/assets.drunagor.app/Profile/user.png'"
-                              alt="Player Image" max-width="90" max-height="90" class="rounded-lg"></v-img>
+                            <v-img
+                              :src="
+                                player.picture_hash
+                                  ? `https://druna-assets.s3.us-east-2.amazonaws.com/Profile/${player.picture_hash}`
+                                  : 'https://s3.us-east-2.amazonaws.com/assets.drunagor.app/Profile/user.png'
+                              "
+                              alt="Player Image"
+                              max-width="90"
+                              max-height="90"
+                              class="rounded-lg"
+                            ></v-img>
                           </v-col>
 
                           <!-- Informações -->
-                          <v-col cols="8" class=" pl-3 d-flex flex-column justify-center">
+                          <v-col
+                            cols="8"
+                            class="pl-3 d-flex flex-column justify-center"
+                          >
                             <p class="font-weight-bold text-truncate">
                               {{ player.user_name }}
                             </p>
                             <p class="text-caption">
                               Status: {{ player.event_status }}
                             </p>
-                            <p v-if="player.status_date" class="text-caption grey--text">
-                              Received: {{ new Date(player.status_date).toLocaleString('en-US', {
-                                year: 'numeric',
-                                month: 'short',
-                                day: 'numeric',
-                                hour: '2-digit',
-                                minute: '2-digit',
-                              }) }}
+                            <p
+                              v-if="player.status_date"
+                              class="text-caption grey--text"
+                            >
+                              Received:
+                              {{
+                                new Date(player.status_date).toLocaleString(
+                                  "en-US",
+                                  {
+                                    year: "numeric",
+                                    month: "short",
+                                    day: "numeric",
+                                    hour: "2-digit",
+                                    minute: "2-digit",
+                                  },
+                                )
+                              }}
                             </p>
                           </v-col>
 
                           <!-- Botões -->
                           <v-col cols="12" md="3" class="d-flex flex-column">
                             <!-- Ícone de Granted Passage, centralizado -->
-                            <template v-if="player.event_status === 'Granted Passage'">
-
-                              <v-btn color="deep-purple" size="x-small" class="mt-2 mt-md-0 pa-0" block
-                                @click="updatePlayerStatus(player, JoinedtheQuest)">
+                            <template
+                              v-if="player.event_status === 'Granted Passage'"
+                            >
+                              <v-btn
+                                color="deep-purple"
+                                size="x-small"
+                                class="mt-2 mt-md-0 pa-0"
+                                block
+                                @click="
+                                  updatePlayerStatus(player, JoinedtheQuest)
+                                "
+                              >
                                 <v-icon start>mdi-flag-checkered</v-icon>
                                 Start Event
                               </v-btn>
 
-                              <v-btn color="red" size="x-small" class="mt-2" block
-                                @click="updatePlayerStatus(player, turnedAwayStatus)">
+                              <v-btn
+                                color="red"
+                                size="x-small"
+                                class="mt-2"
+                                block
+                                @click="
+                                  updatePlayerStatus(player, turnedAwayStatus)
+                                "
+                              >
                                 <v-icon start>mdi-close-circle-outline</v-icon>
                                 Turned Away
                               </v-btn>
-
-
                             </template>
 
-
                             <!-- Se o jogador está participando ativamente -->
-                            <template v-else-if="player.event_status === 'Joined the Quest'">
-                              <v-row no-gutters class="fill-height" align="center" justify="center">
-                                <v-chip color="yellow" text-color="white" class="ma-1" label>
+                            <template
+                              v-else-if="
+                                player.event_status === 'Joined the Quest'
+                              "
+                            >
+                              <v-row
+                                no-gutters
+                                class="fill-height"
+                                align="center"
+                                justify="center"
+                              >
+                                <v-chip
+                                  color="yellow"
+                                  text-color="white"
+                                  class="ma-1"
+                                  label
+                                >
                                   <v-icon left>mdi-sword-cross</v-icon>
                                   Playing
                                 </v-chip>
@@ -481,23 +819,46 @@
                             </template>
 
                             <!-- Ícone de Turned Away, centralizado -->
-                            <template v-else-if="player.event_status === 'Turned Away'">
-                              <v-row no-gutters class="fill-height" align="center" justify="center">
+                            <template
+                              v-else-if="player.event_status === 'Turned Away'"
+                            >
+                              <v-row
+                                no-gutters
+                                class="fill-height"
+                                align="center"
+                                justify="center"
+                              >
                                 <v-btn icon disabled class="ma-0 pa-0">
-                                  <v-icon color="red" size="24">mdi-close-circle</v-icon>
+                                  <v-icon color="red" size="24"
+                                    >mdi-close-circle</v-icon
+                                  >
                                 </v-btn>
                               </v-row>
                             </template>
 
                             <!-- Botões de ação originais, alinhados um abaixo do outro -->
                             <template v-else>
-                              <v-btn color="green" size="x-small" class="mt-2" block
-                                @click="updatePlayerStatus(player, grantedStatus)">
+                              <v-btn
+                                color="green"
+                                size="x-small"
+                                class="mt-2"
+                                block
+                                @click="
+                                  updatePlayerStatus(player, grantedStatus)
+                                "
+                              >
                                 <v-icon start>mdi-check-circle-outline</v-icon>
                                 Granted Passage
                               </v-btn>
-                              <v-btn color="red" size="x-small" class="mt-2" block
-                                @click="updatePlayerStatus(player, turnedAwayStatus)">
+                              <v-btn
+                                color="red"
+                                size="x-small"
+                                class="mt-2"
+                                block
+                                @click="
+                                  updatePlayerStatus(player, turnedAwayStatus)
+                                "
+                              >
                                 <v-icon start>mdi-close-circle-outline</v-icon>
                                 Turned Away
                               </v-btn>
@@ -507,14 +868,24 @@
                       </v-card>
                     </v-col>
                     <v-col cols="12" class="d-flex justify-center">
-                      <v-pagination v-model="currentPage" :length="totalPages"></v-pagination>
+                      <v-pagination
+                        v-model="currentPage"
+                        :length="totalPages"
+                      ></v-pagination>
                     </v-col>
                   </v-row>
                 </v-col>
                 <!-- Botões -->
                 <v-col cols="12" class="d-flex justify-space-between">
-                  <v-btn color="red" @click="editEventDialog = false">Close</v-btn>
-                  <v-btn v-if="isEditable" color="green" @click="saveEditedEvent">Save Changes</v-btn>
+                  <v-btn color="red" @click="editEventDialog = false"
+                    >Close</v-btn
+                  >
+                  <v-btn
+                    v-if="isEditable"
+                    color="green"
+                    @click="saveEditedEvent"
+                    >Save Changes</v-btn
+                  >
                 </v-col>
               </v-row>
             </v-card-text>
@@ -557,17 +928,17 @@ const validateTime = () => {
 const availableRewards = ref([]);
 
 const openEditDialog = async (event, editable = false) => {
-  const [datePart, timePart] = event.event_date.split('T');
-  const [hoursStr, minutesStr] = timePart.split(':');
+  const [datePart, timePart] = event.event_date.split("T");
+  const [hoursStr, minutesStr] = timePart.split(":");
   const hours24 = parseInt(hoursStr, 10);
   const minutes = minutesStr;
   const hours12 = hours24 % 12 || 12;
-  const ampm = hours24 >= 12 ? 'PM' : 'AM';
+  const ampm = hours24 >= 12 ? "PM" : "AM";
 
   editableEvent.value = {
     events_pk: event.events_pk,
     date: datePart,
-    hour: `${String(hours12).padStart(2, '0')}:${minutes}`,
+    hour: `${String(hours12).padStart(2, "0")}:${minutes}`,
     ampm,
     seats_number: event.seats_number,
     sceneries: event.scenario,
@@ -587,8 +958,8 @@ const openEditDialog = async (event, editable = false) => {
   await fetchAllRewards();
   eventRewards.value = await fetchEventRewards(event.events_pk);
 
-  editableEvent.value.rewards = availableRewards.value.filter(ar =>
-    rewardsFromRelation.some(rr => rr.rewards_pk === ar.rewards_pk)
+  editableEvent.value.rewards = availableRewards.value.filter((ar) =>
+    rewardsFromRelation.some((rr) => rr.rewards_pk === ar.rewards_pk),
   );
 
   console.log("🟢 Rewards sincronizados:", editableEvent.value.rewards);
@@ -600,10 +971,13 @@ const pageSize = 5;
 const totalPages = computed(() => Math.ceil(players.value.length / pageSize));
 
 const paginatedPlayers = computed(() => {
-  const eventFk = selectedEvent.value?.events_pk ? Number(selectedEvent.value.events_pk) : null;
-  const allPlayers = eventFk && playersByEvent.value[eventFk]
-    ? playersByEvent.value[eventFk]
-    : [];
+  const eventFk = selectedEvent.value?.events_pk
+    ? Number(selectedEvent.value.events_pk)
+    : null;
+  const allPlayers =
+    eventFk && playersByEvent.value[eventFk]
+      ? playersByEvent.value[eventFk]
+      : [];
   const start = (currentPage.value - 1) * pageSize;
 
   return allPlayers.slice(start, start + pageSize);
@@ -651,7 +1025,7 @@ const fetchPlayersForEvent = async (eventFk) => {
     } else {
       console.error(
         `Erro ao buscar jogadores para o evento ${eventFk}:`,
-        error.response?.data || error.message
+        error.response?.data || error.message,
       );
       playersByEvent.value[Number(eventFk)] = [];
     }
@@ -683,15 +1057,11 @@ const updatePlayerStatus = async (player, statusPk) => {
       active: true,
     };
 
-    const response = await axios.post(
-      "/rl_events_users/cadastro",
-      payload,
-      {
-        headers: {
-          Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
-        },
-      }
-    );
+    const response = await axios.post("/rl_events_users/cadastro", payload, {
+      headers: {
+        Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+      },
+    });
 
     player.event_status = response.data.event_status || player.event_status;
     fetchPlayersForEvent(eventFk);
@@ -709,7 +1079,7 @@ const updatePlayerStatus = async (player, statusPk) => {
             headers: {
               Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
             },
-          }
+          },
         );
       }
     }
@@ -717,11 +1087,10 @@ const updatePlayerStatus = async (player, statusPk) => {
     console.error("Error updating player status:", {
       request: error.config?.data,
       response: error.response?.data,
-      message: error.message
+      message: error.message,
     });
   }
 };
-
 
 const dateRules = [
   (value) => {
@@ -847,10 +1216,8 @@ const fetchPlayerEvents = async () => {
       },
     });
 
-
     events.value = response.data.events || [];
     console.log("📦 Eventos carregados:", events.value);
-    
   } catch (error) {
     console.error(
       "❌ Erro ao buscar eventos do jogador:",
@@ -873,16 +1240,22 @@ onMounted(() => {
 const sceneries = ref([]);
 
 const fetchSceneries = async () => {
-  await axios.get('/sceneries/search', {
-    params: { active: true },
-    headers: {
-      Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
-    },
-  }).then((response) => {
-    sceneries.value = [...response.data.sceneries];
-  }).catch((error) => {
-    console.error("❌ Erro ao buscar cenários:", error.response?.data || error.message);
-  })
+  await axios
+    .get("/sceneries/search", {
+      params: { active: true },
+      headers: {
+        Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+      },
+    })
+    .then((response) => {
+      sceneries.value = [...response.data.sceneries];
+    })
+    .catch((error) => {
+      console.error(
+        "❌ Erro ao buscar cenários:",
+        error.response?.data || error.message,
+      );
+    });
 };
 
 onMounted(async () => {
@@ -961,7 +1334,6 @@ const addEvent = async () => {
       },
     });
 
-
     const newEventId = response.data?.event?.events_pk;
 
     if (!newEventId) {
@@ -971,17 +1343,20 @@ const addEvent = async () => {
 
     // ✅ Adiciona rewards ao evento
     for (const reward of selectedRewards.value) {
-
       try {
-        await axios.post("/rl_events_rewards/cadastro", {
-          events_fk: newEventId,
-          rewards_fk: reward.rewards_pk,
-          active: true
-        }, {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+        await axios.post(
+          "/rl_events_rewards/cadastro",
+          {
+            events_fk: newEventId,
+            rewards_fk: reward.rewards_pk,
+            active: true,
           },
-        });
+          {
+            headers: {
+              Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+            },
+          },
+        );
       } catch (err) {
         console.error("❌ Erro ao associar reward ao evento:", err);
       }
@@ -997,18 +1372,17 @@ const addEvent = async () => {
   }
 
   newEvent.value = {
-    date: '',
-    hour: '',
-    ampm: 'AM',
-    store: '',
-    seats: '',
-    scenario: ''
+    date: "",
+    hour: "",
+    ampm: "AM",
+    store: "",
+    seats: "",
+    scenario: "",
   };
 
   selectedRewards.value = [];
 
   createEventDialog.value = false;
-
 };
 
 const deleteEvent = async (events_pk) => {
@@ -1019,11 +1393,13 @@ const deleteEvent = async (events_pk) => {
       },
     });
 
-
     await fetchUserCreatedEvents();
     await fetchPlayerEvents();
   } catch (error) {
-    console.error("❌ Erro ao excluir o evento:", error.response?.data || error.message);
+    console.error(
+      "❌ Erro ao excluir o evento:",
+      error.response?.data || error.message,
+    );
   }
 };
 
@@ -1058,7 +1434,21 @@ const fetchUserCreatedEvents = async () => {
 
 onMounted(fetchUserCreatedEvents);
 
+const loading = ref(false);
 
+async function loadList() {
+  loading.value = true;
+  if (activeTab.value === 1) {
+    await fetchPlayerEvents();
+  } else {
+    await fetchUserCreatedEvents();
+  }
+  loading.value = false;
+}
+
+watch(activeTab, loadList);
+
+onMounted(loadList);
 
 const createEventDialog = ref(false);
 const newEvent = ref({});
@@ -1145,53 +1535,75 @@ const saveEditedEvent = async () => {
     });
 
     // 🔄 Pega os rewards já salvos na relação para este evento
-    const existingRelationsRes = await axios.get("/rl_events_rewards/list_rewards", {
-      params: { events_fk: eventPk },
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+    const existingRelationsRes = await axios.get(
+      "/rl_events_rewards/list_rewards",
+      {
+        params: { events_fk: eventPk },
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+        },
       },
-    });
+    );
 
     const currentRelations = existingRelationsRes.data.rewards || [];
-    const currentIds = currentRelations.map(r => r.rewards_pk);
-    const updatedIds = editableEvent.value.rewards.map(r => r.rewards_pk);
+    const currentIds = currentRelations.map((r) => r.rewards_pk);
+    const updatedIds = editableEvent.value.rewards.map((r) => r.rewards_pk);
 
     // ➕ Adicionar novos rewards
-    const toAdd = updatedIds.filter(id => !currentIds.includes(id));
+    const toAdd = updatedIds.filter((id) => !currentIds.includes(id));
     for (const rewards_fk of toAdd) {
-      console.log("🔼 Tentando adicionar reward:", { events_fk: eventPk, rewards_fk });
+      console.log("🔼 Tentando adicionar reward:", {
+        events_fk: eventPk,
+        rewards_fk,
+      });
       try {
-        await axios.post("/rl_events_rewards/cadastro", {
-          events_fk: eventPk,
-          rewards_fk,
-          active: true,
-        }, {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+        await axios.post(
+          "/rl_events_rewards/cadastro",
+          {
+            events_fk: eventPk,
+            rewards_fk,
+            active: true,
           },
-        });
+          {
+            headers: {
+              Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+            },
+          },
+        );
         console.log("✅ Reward adicionado com sucesso:", rewards_fk);
       } catch (err) {
-        console.error("❌ Erro ao adicionar reward:", rewards_fk, err.response?.data || err.message);
+        console.error(
+          "❌ Erro ao adicionar reward:",
+          rewards_fk,
+          err.response?.data || err.message,
+        );
       }
     }
 
     // ❌ Remover (inativar) os desmarcados
-    const toRemove = currentIds.filter(id => !updatedIds.includes(id));
+    const toRemove = currentIds.filter((id) => !updatedIds.includes(id));
     for (const rewards_fk of toRemove) {
       try {
-        await axios.post("/rl_events_rewards/cadastro", {
-          events_fk: eventPk,
-          rewards_fk,
-          active: false,
-        }, {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+        await axios.post(
+          "/rl_events_rewards/cadastro",
+          {
+            events_fk: eventPk,
+            rewards_fk,
+            active: false,
           },
-        });
+          {
+            headers: {
+              Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+            },
+          },
+        );
         console.log("🗑️ Reward inativado com sucesso:", rewards_fk);
       } catch (err) {
-        console.error("❌ Erro ao inativar reward:", rewards_fk, err.response?.data || err.message);
+        console.error(
+          "❌ Erro ao inativar reward:",
+          rewards_fk,
+          err.response?.data || err.message,
+        );
       }
     }
 
@@ -1204,46 +1616,62 @@ const saveEditedEvent = async () => {
     editEventDialog.value = false;
     await fetchUserCreatedEvents();
   } catch (error) {
-    console.error("Erro ao alterar o evento:", error.response?.data || error.message);
+    console.error(
+      "Erro ao alterar o evento:",
+      error.response?.data || error.message,
+    );
   }
 };
 
 const toggleEditReward = async (reward) => {
   const eventId = editableEvent.value.events_pk;
-  const alreadySelected = editableEvent.value.rewards.some(r => r.rewards_pk === reward.rewards_pk);
+  const alreadySelected = editableEvent.value.rewards.some(
+    (r) => r.rewards_pk === reward.rewards_pk,
+  );
 
   try {
     if (alreadySelected) {
-      await axios.post("/rl_events_rewards/cadastro", {
-        events_fk: eventId,
-        rewards_fk: reward.rewards_pk,
-        active: false
-      }, {
-        headers: {
-          Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+      await axios.post(
+        "/rl_events_rewards/cadastro",
+        {
+          events_fk: eventId,
+          rewards_fk: reward.rewards_pk,
+          active: false,
         },
-      });
+        {
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+          },
+        },
+      );
 
       editableEvent.value.rewards = editableEvent.value.rewards.filter(
-        r => r.rewards_pk !== reward.rewards_pk
+        (r) => r.rewards_pk !== reward.rewards_pk,
       );
     } else {
-      await axios.post("/rl_events_rewards/cadastro", {
-        events_fk: eventId,
-        rewards_fk: reward.rewards_pk,
-        active: true
-      }, {
-        headers: {
-          Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+      await axios.post(
+        "/rl_events_rewards/cadastro",
+        {
+          events_fk: eventId,
+          rewards_fk: reward.rewards_pk,
+          active: true,
         },
-      });
+        {
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+          },
+        },
+      );
 
       editableEvent.value.rewards.push(reward);
     }
 
     console.log("✅ Rewards atualizados:", editableEvent.value.rewards);
   } catch (error) {
-    console.error("❌ Erro ao atualizar rewards:", error.response?.data || error.message);
+    console.error(
+      "❌ Erro ao atualizar rewards:",
+      error.response?.data || error.message,
+    );
   }
 };
 
@@ -1257,7 +1685,6 @@ const handleEditImageUpload = (event) => {
     reader.readAsDataURL(file);
   }
 };
-
 
 const allRewards = ref([]);
 
@@ -1279,7 +1706,6 @@ const eventRewards = ref([]);
 
 const fetchEventRewards = async (eventId) => {
   try {
-
     const response = await axios.get("/rl_events_rewards/list_rewards", {
       params: { events_fk: eventId },
       headers: {
@@ -1301,7 +1727,7 @@ const fetchEventRewards = async (eventId) => {
         } catch (err) {
           return null;
         }
-      })
+      }),
     );
 
     return fullRewards.filter(Boolean); // 🔁 Aqui retorna a lista válida
@@ -1315,11 +1741,11 @@ const handleShareEvent = (eventId) => {
   const shareLink = generateShareEventLink(eventId);
   if (shareLink) {
     sharedLink.value = shareLink; // supondo que sharedLink seja uma ref()
-    showCard.value = true;         // e que showCard controle exibir o card
+    showCard.value = true; // e que showCard controle exibir o card
   }
 };
 
-const sharedLink = ref('');
+const sharedLink = ref("");
 const showDialog = ref(false);
 const showAlert = ref(false);
 
@@ -1341,24 +1767,21 @@ const copyLink = async (link) => {
   try {
     await navigator.clipboard.writeText(link);
     showDialog.value = false; // Fecha o popup
-    showAlert.value = true;   // Mostra o alerta
+    showAlert.value = true; // Mostra o alerta
   } catch (error) {
     console.error("Erro ao copiar o link:", error);
   }
 };
 
-
-
 onMounted(() => {
   fetchAllRewards();
 });
-
-
-
-
 </script>
 
 <style scoped>
+.list-container {
+  min-height: 400px; /* adjust as needed to prevent shrinking */
+}
 /* Event Card */
 .event-card {
   display: flex;

--- a/src/components/UserEvents.vue
+++ b/src/components/UserEvents.vue
@@ -9,354 +9,197 @@
 
   <v-col cols="12" md="10" class="mx-auto">
     <v-card class="pb-12" min-height="500px" color="#151515">
+      <!-- Tabs -->
       <v-row no-gutters>
         <v-col cols="12">
-          <v-tabs class="EventsTabs mb-3" v-model="activeTab" fixed-tabs align-tabs="center" color="white">
+          <v-tabs
+            class="EventsTabs mb-3"
+            v-model="activeTab"
+            fixed-tabs
+            align-tabs="center"
+            color="white"
+          >
             <v-tab class="text-h5" :value="1">ALL EVENTS</v-tab>
             <v-tab class="text-h5" :value="2">MY EVENTS</v-tab>
           </v-tabs>
         </v-col>
       </v-row>
 
+      <!-- ALL EVENTS -->
       <div v-if="activeTab === 1">
-        <v-row>
-          <v-col class="py-2 pl-1 pr-1" cols="12" md="6" v-for="(event, index) in sortedEvents" :key="index">
-            <v-card color="terciary" class="pt-0 event-card" @click="openDialog(event)">
-              <v-row no-gutters>
-                <v-col cols="4" sm="2">
-                  <div class="text-center ml-3" style="width: 70px; color: black">
-                    <p class="pt-3 text-caption font-weight-bold">
-                      {{
-                        new Date(event.event_date)
-                          .toLocaleDateString("en-US", {
-                            month: "short",
+        <!-- Loading spinner -->
+        <div v-if="loading" class="d-flex justify-center my-8">
+          <v-progress-circular indeterminate size="48" color="primary" />
+        </div>
+        <!-- Event list -->
+        <div v-else class="list-container">
+          <v-row>
+            <v-col
+              v-for="(event, index) in sortedEvents"
+              :key="index"
+              class="py-2 pl-1 pr-1"
+              cols="12"
+              md="6"
+            >
+              <v-card color="terciary" class="pt-0 event-card" @click="openDialog(event)">
+                <v-row no-gutters>
+                  <v-col cols="4" sm="2">
+                    <div class="text-center ml-3" style="width: 70px; color: black">
+                      <p class="pt-3 text-caption font-weight-bold">
+                        {{
+                          new Date(event.event_date)
+                            .toLocaleDateString("en-US", { month: "short" })
+                            .toUpperCase()
+                        }}
+                      </p>
+                      <p class="cinzel-text text-h3 font-weight-bold">
+                        {{ String(event.event_date).split("T")[0].split("-")[2] }}
+                      </p>
+                      <p class="text-caption font-weight-bold">
+                        {{
+                          new Date(event.event_date).toLocaleTimeString("en-US", {
+                            hour: "2-digit",
+                            minute: "2-digit",
+                            hour12: true,
                           })
-                          .toUpperCase()
-                      }}
+                        }}
+                      </p>
+                    </div>
+                  </v-col>
+                  <v-col cols="8" sm="10" class="pt-2">
+                    <h3 class="pb-1">
+                      <v-icon class="pr-1" size="small" color="black">mdi-chess-rook</v-icon>
+                      {{ event.store_name }}
+                    </h3>
+                    <p class="text-caption text-truncate">
+                      <v-icon color="red">mdi-map-marker</v-icon>
+                      {{ event.address }}
                     </p>
-                    <p color="primary" class="cinzel-text text-h3 font-weight-bold">
-                      {{ String(event.event_date).split("T")[0].split("-")[2] }}
+                    <p class="text-caption">
+                      <v-icon color="red">mdi-sword-cross</v-icon>
+                      {{ event.scenario }}
                     </p>
-                    <p class="text-caption font-weight-bold">
-                      {{
-                        new Date(event.event_date).toLocaleTimeString("en-US", {
-                          hour: "2-digit",
-                          minute: "2-digit",
-                          hour12: true,
-                        })
-                      }}
+                    <p
+                      class="text-caption ml-3"
+                      v-if="event.rewards?.length"
+                    >
+                      <v-row class="d-flex align-center rewards-container">
+                        <v-icon class="mr-1" color="red">mdi-star-circle</v-icon>
+                        Rewards:
+                        <v-col
+                          v-for="(reward, i) in event.rewards"
+                          :key="i"
+                          cols="auto"
+                        >
+                          <v-img
+                            :src="reward.image"
+                            height="20"
+                            width="20"
+                            contain
+                            class="reward-icon"
+                          />
+                        </v-col>
+                      </v-row>
                     </p>
-                  </div>
-                </v-col>
-                <v-col cols="8" sm="10" class="pt-2">
-                  <h3 class="pb-1">
-                    <v-icon class="pr-1" size="small" color="black">mdi-chess-rook</v-icon>{{ event.store_name }}
-                  </h3>
-                  <p class="text-caption text-truncate">
-                    <v-icon color="red">mdi-map-marker</v-icon>
-                    {{ event.address }}
-                  </p>
-                  <p class="text-caption">
-                    <v-icon color="red">mdi-sword-cross</v-icon>
-                    {{ event.scenario }}
-                  </p>
-
-                  <p class="text-caption ml-3" v-if="event.rewards && event.rewards.length">
-                    <v-row class="d-flex align-center rewards-container">
-                      <v-icon class="mr-1" color="red">mdi-star-circle</v-icon>
-                      Rewards:
-                      <v-col cols="auto" v-for="(reward, index) in event.rewards" :key="index">
-                        <v-img :src="reward.image" height="20" width="20" contain class="reward-icon"></v-img>
-                      </v-col>
-                    </v-row>
-                  </p>
-                </v-col>
-              </v-row>
-            </v-card>
-          </v-col>
-        </v-row>
-        <v-dialog v-model="dialog" max-width="600" min-height="431">
-          <v-card color="surface">
-            <v-card-actions class="d-flex justify-left">
-              <v-btn color="red" @click="dialog = false">X</v-btn>
-            </v-card-actions>
-
-            <v-dialog v-model="showDialog" width="400">
-              <v-card>
-                <v-card-title class="text-h6">Share Event</v-card-title>
-                <v-card-text>
-                  <v-text-field v-model="sharedLink" label="Event Link" readonly density="compact"
-                    hide-details></v-text-field>
-                </v-card-text>
-                <v-card-actions>
-                  <v-spacer></v-spacer>
-                  <v-btn color="success" size="small" @click="copyLink(sharedLink)">
-                    Copy Link
-                  </v-btn>
-                  <v-btn color="grey" size="small" @click="showDialog = false">
-                    Close
-                  </v-btn>
-                </v-card-actions>
+                  </v-col>
+                </v-row>
               </v-card>
-            </v-dialog>
-            <v-card-text>
-              <p></p>
-              <v-btn block color="blue" size="small" variant="flat" class="mt-2"
-                @click="shareEvent(selectedEvent?.events_pk)">
-                <v-icon start>mdi-share-variant</v-icon>
-                Share Event
-              </v-btn>
-              <br />
-              <p><v-icon>mdi-seat</v-icon> Disponible Seats: {{ selectedEvent?.seats_number }}</p>
-              <p><v-icon>mdi-sword-cross</v-icon> Scenario: {{ selectedEvent?.scenario }}</p>
-              <br />
-              <p class="text-end scheduled-box">
-                Scheduled for:
-                {{
-                  new Date(selectedEvent?.event_date).toLocaleString("en-US", {
-                    month: "2-digit",
-                    day: "2-digit",
-                    year: "numeric",
-                    hour: "2-digit",
-                    minute: "2-digit",
-                    hour12: true,
-                  })
-                }}
-              </p>
-            </v-card-text>
-            <v-card color="primary" min-height="130px" class="mr-4 event-card">
-              <v-row no-gutters>
-                <v-col cols="3" lg="3">
-                  <v-img :src="selectedEvent?.picture_hash
-                      ? `https://druna-assets.s3.us-east-2.amazonaws.com/${selectedEvent.picture_hash}`
-                      : 'https://s3.us-east-2.amazonaws.com/assets.drunagor.app/Profile/store.png'
-                    " class="event-img" />
-                </v-col>
-                <v-col cols="9" class="pa-2">
-                  <h3 class="text-subtitle-1 font-weight-bold">
-                    {{ selectedEvent?.store_name }}
-                  </h3>
-                  <p class="text-caption">
-                    <v-icon color="red">mdi-map-marker</v-icon>
-                    {{ selectedEvent?.address }}
-                  </p>
-                </v-col>
-                <v-col cols="2" class="text-right pa-0"></v-col>
-              </v-row>
-            </v-card>
-            <v-card-text v-if="eventRewards.length">
-              <h3 class="text-h6 font-weight-bold">REWARDS:</h3>
-              <v-row v-for="(reward, index) in eventRewards" :key="index" class="align-center my-2">
-                <v-col cols="3" md="2">
-                  <v-avatar size="60">
-                    <v-img :src="`https://druna-assets.s3.us-east-2.amazonaws.com/${reward.picture_hash}`" />
-                  </v-avatar>
-                </v-col>
-                <v-col cols="9" md="10">
-                  <h4 class="text-subtitle-1 font-weight-bold">{{ reward.name }}</h4>
-                  <p class="text-body-2">{{ reward.description }}</p>
-                </v-col>
-              </v-row>
-            </v-card-text>
-            <v-row class="mt-2 ml-0">
-              <v-col cols="12" class="mb-2">
-                <v-btn block color="#539041" class="rounded-0" @click="joinEvent">
-                  Count me in
-                </v-btn>
-
-                <v-alert v-if="showSuccessAlert" type="success" class="mt-4" border="start" variant="tonal" closable
-                  @click:close="showSuccessAlert = false">
-                  You’ve successfully joined this event! Visit the <strong>My Events</strong> page to view it.
-                </v-alert>
-
-              </v-col>
-            </v-row>
-          </v-card>
-        </v-dialog>
-
+            </v-col>
+          </v-row>
+        </div>
       </div>
 
+      <!-- MY EVENTS -->
       <div v-else-if="activeTab === 2">
-        <v-row>
-          <v-col class="py-2 pl-1 pr-1" cols="12" md="6" v-for="(evt, idx) in myEvents" :key="evt.events_pk">
-            <v-card color="terciary" class="pt-0 event-card" @click="openMyEventsDialog(evt)">
-              <v-row no-gutters>
-                <v-col cols="4" sm="2">
-                  <div class="text-center ml-3" style="width: 70px; color: black">
-                    <p class="pt-3 text-caption font-weight-bold">
-                      {{
-                        new Date(evt.event_date)
-                          .toLocaleDateString("en-US", { month: "short" })
-                          .toUpperCase()
-                      }}
+        <!-- Loading spinner -->
+        <div v-if="loading" class="d-flex justify-center my-8">
+          <v-progress-circular indeterminate size="48" color="primary" />
+        </div>
+        <!-- My events list -->
+        <div v-else class="list-container">
+          <v-row>
+            <v-col
+              v-for="(evt, idx) in myEvents"
+              :key="evt.events_pk"
+              class="py-2 pl-1 pr-1"
+              cols="12"
+              md="6"
+            >
+              <v-card
+                color="terciary"
+                class="pt-0 event-card"
+                @click="openMyEventsDialog(evt)"
+              >
+                <v-row no-gutters>
+                  <v-col cols="4" sm="2">
+                    <div class="text-center ml-3" style="width: 70px; color: black">
+                      <p class="pt-3 text-caption font-weight-bold">
+                        {{
+                          new Date(evt.event_date)
+                            .toLocaleDateString("en-US", { month: "short" })
+                            .toUpperCase()
+                        }}
+                      </p>
+                      <p class="cinzel-text text-h3 font-weight-bold">
+                        {{ String(evt.event_date).split("T")[0].split("-")[2] }}
+                      </p>
+                      <p class="text-caption font-weight-bold">
+                        {{
+                          new Date(evt.event_date).toLocaleTimeString("en-US", {
+                            hour: "2-digit",
+                            minute: "2-digit",
+                            hour12: true,
+                          })
+                        }}
+                      </p>
+                    </div>
+                  </v-col>
+                  <v-col cols="8" sm="9" class="pt-2">
+                    <h3 class="pb-1">
+                      <v-icon class="pr-1" size="small" color="black">mdi-chess-rook</v-icon>
+                      {{ evt.store_name }}
+                    </h3>
+                    <p class="text-caption text-truncate">
+                      <v-icon color="red">mdi-map-marker</v-icon>
+                      {{ evt.address }}
                     </p>
-                    <p class="cinzel-text text-h3 font-weight-bold">
-                      {{ String(evt.event_date).split("T")[0].split("-")[2] }}
+                    <p class="text-caption">
+                      <v-icon color="red">mdi-sword-cross</v-icon>
+                      {{ evt.scenario }}
                     </p>
-                    <p class="text-caption font-weight-bold">
-                      {{
-                        new Date(evt.event_date).toLocaleTimeString("en-US", {
-                          hour: "2-digit",
-                          minute: "2-digit",
-                          hour12: true,
-                        })
-                      }}
+                    <p class="text-caption">
+                      Seats: {{ evt.seats_number }} | Season: {{ evt.seasons_fk }}
                     </p>
-                  </div>
-                </v-col>
-
-                <v-col cols="8" sm="9" class="pt-2">
-                  <h3 class="pb-1">
-                    <v-icon class="pr-1" size="small" color="black">mdi-chess-rook</v-icon>
-                    {{ evt.store_name }}
-                  </h3>
-                  <p class="text-caption text-truncate">
-                    <v-icon color="red">mdi-map-marker</v-icon>
-                    {{ evt.address }}
-                  </p>
-                  <p class="text-caption">
-                    <v-icon color="red">mdi-sword-cross</v-icon>
-                    {{ evt.scenario }}
-                  </p>
-                  <p class="text-caption">
-                    Seats: {{ evt.seats_number }} | Season: {{ evt.seasons_fk }}
-                  </p>
-                </v-col>
-
-                <v-col cols="0" sm="1" class="d-flex align-center justify-end pr-2">
-                  <v-tooltip :text="getEventStatusInfo(evt.status).tooltip" location="top">
-                    <template v-slot:activator="{ props }">
-                      <v-icon v-bind="props" :color="getEventStatusInfo(evt.status).color" size="large">
-                        {{ getEventStatusInfo(evt.status).icon }}
-                      </v-icon>
-                    </template>
-                  </v-tooltip>
-                </v-col>
-              </v-row>
-            </v-card>
-          </v-col>
-        </v-row>
-        <v-dialog v-model="myDialog" max-width="700" min-height="500">
-          <v-card color="surface" class="pa-6">
-            <div v-if="loading" class="dialog-overlay">
-              <v-progress-circular
-                indeterminate
-                :size="80"
-                :width="7"
-                color="primary"
-              ></v-progress-circular>
-            </div>
-            <div class="d-flex align-center justify-space-between pl-8">
-              <v-card-title class="text-h6 font-weight-bold pa-0">
-                {{ selectedMyEvent?.store_name }}
-              </v-card-title>
-              <v-icon color="red" @click="myDialog = false" class="mr-2" style="cursor: pointer;">
-                mdi-close
-              </v-icon>
-            </div>
-
-            <div class="mt-1 pl-6" style="display: inline-block;">
-              <p class="text-caption scheduled-box ma-0 ml-">
-                Scheduled for:
-                {{
-                  new Date(selectedMyEvent?.event_date).toLocaleString("en-US", {
-                    month: "2-digit",
-                    day: "2-digit",
-                    year: "numeric",
-                    hour: "2-digit",
-                    minute: "2-digit",
-                    hour12: true,
-                  })
-                }}
-              </p>
-            </div>
-
-            <v-row class="" align="center" justify="space-between">
-              <v-col cols="12" md="6" class="text-center pt-8 ml-3">
-                <div
-                  style="position: relative; display: inline-block; background: white; padding: 8px; border-radius: 8px;">
-                  <v-img
-                    src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d0/QR_code_for_mobile_English_Wikipedia.svg/1200px-QR_code_for_mobile_English_Wikipedia.svg.png"
-                    width="180" height="180" class="rounded" style="opacity: 0.3; filter: grayscale(1);" />
-                  <div style="
-                      position: absolute;
-                      top: 50%;
-                      left: 50%;
-                      transform: translate(-50%, -50%) rotate(-10deg);
-                      font-weight: 600;
-                      font-size: 0.9rem;
-                      color: #999;
-                      background-color: rgba(255, 255, 255, 0.7);
-                      padding: 4px 10px;
-                      border-radius: 4px;
-                      text-transform: uppercase;
-                      letter-spacing: 1px;
-                    ">
-                    Coming Soon
-                  </div>
-                </div>
-              </v-col>
-
-              <v-col cols="12" md="5" class="text-center ml-3 px-5 px-md-0 mr-md-7 pr-md-3">
-                <p class="text-subtitle-2 font-weight-medium mb-2">
-                  Status: {{ selectedMyEvent?.status }}
-                </p>
-                <v-btn
-                  class="mb-4"
-                  block
-                  color="green"
-                  @click="handleNewCampaign('underkeep')"
-                  :disabled="!currentPlayer || currentPlayer.event_status !== 'Joined the Quest'"
-                >
-                  Join Campaign
-                </v-btn>
-                <v-btn class="mb-8" block color="red" @click="quitEvent()">
-                  Quit Event
-                </v-btn>
-              </v-col>
-            </v-row>
-
-            <v-card color="primary" min-height="130px" class="mr-4 event-card">
-              <v-row no-gutters>
-                <v-col cols="3" lg="3">
-                  <v-img :src="selectedMyEvent?.picture_hash
-                      ? `https://druna-assets.s3.us-east-2.amazonaws.com/${selectedMyEvent.picture_hash}`
-                      : 'https://s3.us-east-2.amazonaws.com/assets.drunagor.app/Profile/store.png'
-                    " class="event-img" />
-                </v-col>
-                <v-col cols="9" class="pa-2">
-                  <h3 class="text-subtitle-1 font-weight-bold">
-                    {{ selectedMyEvent?.store_name }}
-                  </h3>
-                  <p class="text-caption">
-                    <v-icon color="red">mdi-map-marker</v-icon>
-                    {{ selectedMyEvent?.address }}
-                  </p>
-                </v-col>
-                <v-col cols="2" class="text-right pa-0"></v-col>
-              </v-row>
-            </v-card>
-          </v-card>
-        </v-dialog>
-
-        <v-dialog v-model="showQuitConfirmDialog" max-width="400">
-          <v-card>
-            <v-card-title class="text-h6">Confirm Exit</v-card-title>
-            <v-card-text>
-              Are you sure you want to quit this event? This action cannot be undone.
-            </v-card-text>
-            <v-card-actions>
-              <v-spacer></v-spacer>
-              <v-btn color="grey" text @click="showQuitConfirmDialog = false">Cancel</v-btn>
-              <v-btn color="red-darken-2" text @click="confirmQuitEvent">Quit Event</v-btn>
-            </v-card-actions>
-          </v-card>
-        </v-dialog>
-
+                  </v-col>
+                  <v-col cols="1" class="d-flex align-center justify-end pr-2">
+                    <v-tooltip :text="getEventStatusInfo(evt.status).tooltip" location="top">
+                      <template #activator="{ props }">
+                        <v-icon
+                          v-bind="props"
+                          :color="getEventStatusInfo(evt.status).color"
+                          size="large"
+                        >
+                          {{ getEventStatusInfo(evt.status).icon }}
+                        </v-icon>
+                      </template>
+                    </v-tooltip>
+                  </v-col>
+                </v-row>
+              </v-card>
+            </v-col>
+          </v-row>
+        </div>
       </div>
     </v-card>
   </v-col>
 </template>
+
+<style scoped>
+.list-container {
+  min-height: 400px; /* evita encolhimento */
+}
+</style>
+
 
 <script setup>
 import { ref, computed, watch, onMounted, inject } from "vue";
@@ -744,6 +587,20 @@ const fetchMyEvents = async () => {
   });
   myEvents.value = res.data.events || [];
 };
+
+async function loadTabData() {
+  loading.value = true
+  if (activeTab.value === 1) {
+    await fetchPlayerEvents()
+  } else {
+    await fetchMyEvents()
+  }
+  loading.value = false
+}
+
+watch(activeTab, () => {
+  loadTabData()
+}, { immediate: true })
 
 onMounted(async () => {
   await Promise.all([fetchPlayerEvents(), fetchMyEvents()]);
@@ -1174,6 +1031,9 @@ const getEventStatusInfo = (status) => {
 </script>
 
 <style scoped>
+.list-container {
+  min-height: 400px;
+}
 .event-card {
   display: flex;
   align-items: center;


### PR DESCRIPTION
- Show `<v-progress-circular>` while fetching events (controlled by `loading`)
- Wrap events lists in `.list-container` with a `min-height` to prevent collapse
- Trigger list refresh on `activeTab` change via `watch(activeTab)`