### PR TITLE
refactor(ui): replace direct v-alerts with reusable BaseAlert compone…

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -13,6 +13,7 @@ declare module 'vue' {
     AppFooter: typeof import('./components/AppFooter.vue')['default']
     Badges: typeof import('./components/Badges.vue')['default']
     BadgesUser: typeof import('./components/BadgesUser.vue')['default']
+    BaseAlert: typeof import('./components/Alerts/BaseAlert.vue')['default']
     BaseList: typeof import('./components/BaseList.vue')['default']
     BaseListItem: typeof import('./components/BaseListItem.vue')['default']
     BaseListSearch: typeof import('./components/BaseListSearch.vue')['default']

--- a/src/components/AccountForm.vue
+++ b/src/components/AccountForm.vue
@@ -20,16 +20,17 @@
         <!-- Conteúdo do formulário (visível apenas se expandido) -->
         <v-expand-transition>
           <v-card-text v-if="isExpanded">
-            <!-- Adicionado ref="alertRef" ao v-alert -->
-            <v-alert
+            <BaseAlert
               ref="alertRef"
-              closable
               v-model="showAlert"
+              :type="alertType"
               :icon="alertIcon"
               :title="alertTitle"
-              :text="alertText"
-              :type="alertType"
-            ></v-alert>
+              text
+              class="mb-4"
+            >
+              {{ alertText }}
+            </BaseAlert>
             <v-form ref="userForm">
               <p class="text-h6 font-weight-medium pl-3 pb-3 pt-5">Name</p>
               <v-text-field
@@ -214,6 +215,7 @@ import { ref, inject, onMounted, reactive, nextTick } from "vue";
 import { useUserStore } from "@/store/UserStore";
 import type { VForm } from "vuetify/components";
 import { getToken } from "@/service/AccessToken";
+import BaseAlert from "@/components/Alerts/BaseAlert.vue";
 
 const userForm = ref<VForm>();
 const userStore = useUserStore();
@@ -245,7 +247,7 @@ const rules = {
     v === form.new_password || "The passwords must match",
   matchEmails: (v: string) => v === form.new_email || "The Emails must match",
 };
-const alertRef = ref<any>(null); // Cria a referência para o v-alert
+const alertRef = ref<any>(null); 
 const alertIcon = ref("");
 const alertText = ref("");
 const alertTitle = ref("");

--- a/src/components/AdOptions.vue
+++ b/src/components/AdOptions.vue
@@ -18,15 +18,16 @@
         <v-expand-transition>
           <v-card-text v-if="isExpanded">
             <!-- Alerta genérico para feedback -->
-            <v-alert
-              closable
+            <BaseAlert
               v-model="showAlert"
+              :type="alertType"
               :icon="alertIcon"
               :title="alertTitle"
-              :text="alertText"
-              :type="alertType"
+              text
               class="mb-6"
-            ></v-alert>
+            >
+              {{ alertText }}
+            </BaseAlert>
 
             <!-- Botão para deletar a conta -->
             <v-btn
@@ -73,6 +74,7 @@
 import { ref, inject } from "vue";
 import { getToken } from "@/service/AccessToken";
 import { useUserStore } from "@/store/UserStore";
+import BaseAlert from "@/components/Alerts/BaseAlert.vue";
 
 // --- Refs e Injeções ---
 const userStore = useUserStore();

--- a/src/components/Alerts/BaseAlert.vue
+++ b/src/components/Alerts/BaseAlert.vue
@@ -1,0 +1,50 @@
+<template>
+  <v-alert
+    v-model="visible"
+    :type="type"
+    :icon="icon"
+    :title="title"
+    :text="text"
+    :border="border"
+    :variant="variant"
+    :color="color"
+    :closable="closable"
+    v-bind="$attrs"
+    @update:modelValue="(val) => $emit('update:modelValue', val)"
+  >
+    <!-- Se você passar conteúdo via slot, ele aparece aqui -->
+    <template v-if="$slots.default">
+      <slot />
+    </template>
+  </v-alert>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from "vue";
+
+const props = defineProps({
+  modelValue: { type: Boolean, default: false },
+  type: {
+    type: String as () => "success" | "error" | "warning" | "info",
+    required: true,
+  },
+  icon: { type: String, default: undefined },
+  title: { type: String, default: undefined },
+  text: { type: Boolean, default: false },
+  border: { type: String, default: undefined },
+  variant: { type: String, default: undefined },
+  color: { type: String, default: undefined },
+  closable: { type: Boolean, default: true },
+});
+const emit = defineEmits<{
+  (e: "update:modelValue", value: boolean): void;
+}>();
+
+// Controle interno de visibilidade, espelhando `modelValue`
+const visible = ref(props.modelValue);
+watch(
+  () => props.modelValue,
+  (v) => (visible.value = v),
+);
+watch(visible, (v) => emit("update:modelValue", v));
+</script>

--- a/src/components/CampaignOverviewView.vue
+++ b/src/components/CampaignOverviewView.vue
@@ -1,17 +1,19 @@
 <template>
   <v-container max-width="680">
     <div v-if="loadingErrors.length > 0" class="mb-4">
-      <v-alert
+      <BaseAlert
         v-for="(error, index) in loadingErrors"
         :key="error.id"
+        :model-value="true"
         type="error"
         title="Loading Error"
-        :text="error.text"
         variant="elevated"
         closable
-        @click:close="loadingErrors.splice(index, 1)"
         class="mb-3"
-      />
+        @update:modelValue="() => loadingErrors.splice(index, 1)"
+      >
+        {{ error.text }}
+      </BaseAlert>
     </div>
 
     <v-card
@@ -176,6 +178,7 @@ import { Hero } from "@/store/Hero";
 import type { HeroData } from "@/data/repository/HeroData";
 import { HeroDataRepository } from "@/data/repository/HeroDataRepository";
 import { useToast } from "primevue/usetoast";
+import BaseAlert from "@/components/Alerts/BaseAlert.vue";
 
 import { customAlphabet } from "nanoid";
 import axios from "axios";

--- a/src/components/CampaignRemove.vue
+++ b/src/components/CampaignRemove.vue
@@ -17,9 +17,9 @@
       }}</v-card-title>
 
       <v-card-text>
-        <v-alert v-model="alertVisible" :type="alertType" closable>
+        <BaseAlert v-model="alertVisible" :type="alertType" closable>
           {{ alertMessage }}
-        </v-alert>
+        </BaseAlert>
 
         <p v-if="!alertVisible" class="text-center mt-2">
           {{ t("text.cannot-be-restored") }}
@@ -65,6 +65,7 @@ import { useRouter } from "vue-router";
 import { HeroStore } from "@/store/HeroStore";
 import { useI18n } from "vue-i18n";
 import axios from "axios";
+import BaseAlert from "@/components/Alerts/BaseAlert.vue";
 
 const campaignStore = CampaignStore();
 const heroStore = HeroStore();

--- a/src/components/CampaignView.vue
+++ b/src/components/CampaignView.vue
@@ -3,10 +3,17 @@
     <v-col cols="12" md="12" lg="12" xl="8">
       <v-card class="mb-2 pa-1" color="primary" style="width: 100%">
         <v-card-text v-if="!showSaveCampaignButton" class="pa-2">
-          <v-alert type="warning" dense border="start" variant="tonal">
+          <BaseAlert
+            :modelValue="true"
+            type="warning"
+            text
+            border="start"
+            variant="tonal"
+            :closable="false"
+          >
             Players can only view this campaign. Only a Drunagor Master can save
             or delete a campaign.
-          </v-alert>
+          </BaseAlert>
         </v-card-text>
         <v-card-actions class="d-flex justify-space-between">
           <v-row no-gutters>
@@ -49,16 +56,17 @@
           </v-row>
         </v-card-actions>
         <v-card-text v-if="showAlert" class="pa-0">
-          <v-alert
-            closable
+          <BaseAlert
             v-model="showAlert"
             :icon="alertIcon"
             :title="alertTitle"
-            :text="alertText"
             :type="alertType"
+            text
             density="compact"
             class="ma-2"
-          ></v-alert>
+          >
+            {{ alertText }}
+          </BaseAlert>
         </v-card-text>
       </v-card>
     </v-col>
@@ -309,6 +317,7 @@ import axios from "axios";
 import { ref as vueRef } from "vue";
 import DialogLoadCampaing from "@/components/dialogs/DialogLoadCampaing.vue";
 import DialogSaveCampaign from "@/components/dialogs/DialogSaveCampaign.vue";
+import BaseAlert from "@/components/Alerts/BaseAlert.vue";
 
 const route = useRoute();
 const campaignStore = CampaignStore();

--- a/src/components/ForgotPassword.vue
+++ b/src/components/ForgotPassword.vue
@@ -32,14 +32,15 @@
                 </v-col>
               </v-row>
             </v-container>
-            <v-alert
-              closable
+            <BaseAlert
               v-model="showAlert"
+              :type="alertType"
               :icon="alertIcon"
               :title="alertTitle"
-              :text="alertText"
-              :type="alertType"
-            ></v-alert>
+              text
+            >
+              {{ alertText }}
+            </BaseAlert>
             <h4 class="text-center mt-4 py-3"></h4>
             <v-form>
               <v-row>
@@ -84,6 +85,7 @@ import TermsCard from "@/components/TermsCard.vue";
 import PrivacyCard from "@/components/PrivacyCard.vue";
 import { setToken } from "@/service/AccessToken";
 import { useUserStore } from "@/store/UserStore";
+import BaseAlert from "@/components/Alerts/BaseAlert.vue";
 
 const userStore = useUserStore();
 
@@ -95,8 +97,8 @@ const alertIcon = ref("");
 const alertText = ref("");
 const alertTitle = ref("");
 const alertType = ref("");
-const termsDialog = ref(false);
 const showAlert = ref(false);
+const termsDialog = ref(false);
 const privacyDialog = ref(false);
 
 const navigateTo = (route: string) => {

--- a/src/components/ProfileBackgroundDialog.vue
+++ b/src/components/ProfileBackgroundDialog.vue
@@ -13,14 +13,16 @@
 
       <v-card-text>
         <v-row v-if="showAlert" no-gutters class="pa-2">
-          <v-alert
-            closable
+          <BaseAlert
+            v-model="showAlert"
+            :type="alertType"
             :icon="alertIcon"
             :title="alertTitle"
-            :text="alertText"
-            :type="alertType"
-            @update:modelValue="showAlert = false"
-          ></v-alert>
+            text
+            class="w-100"
+          >
+            {{ alertText }}
+          </BaseAlert>
         </v-row>
 
         <v-row>
@@ -77,6 +79,7 @@
 import { ref, inject, watch } from "vue";
 import { useUserStore } from "@/store/UserStore";
 import { getToken } from "@/service/AccessToken";
+import BaseAlert from "@/components/Alerts/BaseAlert.vue";
 
 const axios: any = inject("axios");
 const assets = inject<string>("assets");

--- a/src/components/ProfilePicDialog.vue
+++ b/src/components/ProfilePicDialog.vue
@@ -13,14 +13,16 @@
 
       <v-card-text class="py-4">
         <v-row v-if="showAlert" no-gutters class="pa-2 mb-4">
-          <v-alert
-            closable
+          <BaseAlert
+            v-model="showAlert"
+            :type="alertType"
             :icon="alertIcon"
             :title="alertTitle"
-            :text="alertText"
-            :type="alertType"
-            @update:modelValue="showAlert = false"
-          ></v-alert>
+            closable
+            class="w-100"
+          >
+            {{ alertText }}
+          </BaseAlert>
         </v-row>
 
         <v-row justify="start">
@@ -77,6 +79,7 @@
 import { ref, inject, watch } from "vue";
 import { useUserStore } from "@/store/UserStore";
 import { getToken } from "@/service/AccessToken";
+import BaseAlert from "@/components/Alerts/BaseAlert.vue";
 
 const axios: any = inject("axios");
 const assets = inject<string>("assets");

--- a/src/components/StoreForm.vue
+++ b/src/components/StoreForm.vue
@@ -11,16 +11,16 @@
       ADD STORE
     </v-btn>
   </v-col>
-  <v-alert
-    v-if="showVerificationMessage"
+  <BaseAlert
+    v-model="showVerificationMessage"
     type="info"
+    icon="mdi-alert-octagram-outline"
     color="warning"
     class="my-4"
-    icon="mdi-alert-octagram-outline"
   >
     Your store is under review and cannot create events yet. The verification
     process may take up to 3 business days.
-  </v-alert>
+  </BaseAlert>
 
   <v-col cols="12" class="d-flex justify-center pa-0">
     <v-container max-width="800" style="min-width: 360px" class="pa-4">
@@ -308,6 +308,7 @@
 <script lang="ts" setup>
 import { ref, onMounted, computed, inject } from "vue";
 import { useUserStore } from "@/store/UserStore";
+import BaseAlert from "@/components/Alerts/BaseAlert.vue";
 
 // Interface para o formulário de Store
 interface StoreForm {

--- a/src/components/UserDash.vue
+++ b/src/components/UserDash.vue
@@ -17,6 +17,7 @@
                   box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
                   background-color: black;
                 "
+                a
               />
             </v-avatar>
             <v-card-title class="user_nameuser text-h3">{{
@@ -264,17 +265,20 @@
               </v-row>
 
               <div v-if="loadingErrors.length > 0" class="w-100 mt-4 px-4">
-                <v-alert
+                <BaseAlert
                   v-for="(error, index) in loadingErrors"
                   :key="error.id"
+                  v-model="error.visible"
                   type="error"
+                  icon="mdi-alert-octagram-outline"
                   title="Loading Error"
-                  :text="error.text"
                   variant="elevated"
                   closable
-                  @click:close="loadingErrors.splice(index, 1)"
+                  @update:modelValue="() => loadingErrors.splice(index, 1)"
                   class="mb-3"
-                ></v-alert>
+                >
+                  {{ error.text }}
+                </BaseAlert>
               </div>
             </v-col>
           </v-row>
@@ -416,17 +420,20 @@
             </v-row>
 
             <div v-if="loadingErrors.length > 0" class="w-100 mt-4 px-4">
-              <v-alert
+              <BaseAlert
                 v-for="(error, index) in loadingErrors"
                 :key="error.id"
+                v-model="error.visible"
                 type="error"
+                icon="mdi-alert-octagram-outline"
                 title="Loading Error"
-                :text="error.text"
                 variant="elevated"
                 closable
-                @click:close="loadingErrors.splice(index, 1)"
+                @update:modelValue="() => loadingErrors.splice(index, 1)"
                 class="mb-3"
-              ></v-alert>
+              >
+                {{ error.text }}
+              </BaseAlert>
             </div>
           </v-col>
         </v-row>
@@ -450,6 +457,7 @@ import { Campaign } from "@/store/Campaign";
 import { Hero } from "@/store/Hero";
 import { HeroEquipment } from "@/store/Hero";
 import axios from "axios";
+import BaseAlert from "@/components/Alerts/BaseAlert.vue";
 
 const router = useRouter();
 const userStore = useUserStore();
@@ -531,13 +539,16 @@ function getBoxName(boxId: number): string {
 }
 
 function addLoadingError(message: string) {
-  const newError = { id: Date.now(), text: message };
+  const newError = { id: Date.now(), text: message, visible: true };
   loadingErrors.value.push(newError);
+  // opcional: auto‐remover após X segundos
   setTimeout(() => {
-    loadingErrors.value = loadingErrors.value.filter(
-      (e) => e.id !== newError.id,
-    );
+    removeErrorById(newError.id);
   }, 10000);
+}
+
+function removeErrorById(id: number) {
+  loadingErrors.value = loadingErrors.value.filter(e => e.id !== id);
 }
 
 function importCampaign(token: string) {

--- a/src/components/UserEvents.vue
+++ b/src/components/UserEvents.vue
@@ -271,17 +271,16 @@
                 </v-col>
               </v-row>
 
-              <v-alert
-                v-if="showAlert"
+              <BaseAlert
+                v-model="showAlert"
                 :type="alertType"
                 class="mt-4"
                 border="start"
                 variant="tonal"
                 closable
-                @click:close="showAlert = false"
               >
                 <span v-html="alertMessage"></span>
-              </v-alert>
+              </BaseAlert>
             </v-card-text>
 
             <v-row class="mt-2 ml-0">
@@ -490,29 +489,27 @@
                     >
                   </v-col>
                 </v-row>
-                <v-alert
-                  v-if="showQuitSuccessAlert"
+                <BaseAlert
+                  v-model="showQuitSuccessAlert"
                   type="success"
                   title="Success"
                   class="mb-4"
                   variant="tonal"
                   closable
-                  @click:close="showQuitSuccessAlert = false"
                 >
                   You have successfully left the event. It will no longer appear
                   in your list.
-                </v-alert>
-                <v-alert
-                  v-if="showQuitErrorAlert"
+                </BaseAlert>
+                <BaseAlert
+                  v-model="showQuitErrorAlert"
                   type="error"
                   title="Failed to Leave Event"
                   class="mb-4"
                   variant="tonal"
                   closable
-                  @click:close="showQuitErrorAlert = false"
                 >
                   {{ quitErrorMessage }}
-                </v-alert>
+                </BaseAlert>
               </v-col>
             </v-row>
             <v-card
@@ -752,6 +749,7 @@ import { useToast } from "primevue/usetoast";
 import { useI18n } from "vue-i18n";
 import { Campaign } from "@/store/Campaign";
 import { useDebounceFn } from "@vueuse/core";
+import BaseAlert from "@/components/Alerts/BaseAlert.vue";
 
 const router = useRouter();
 const toast = useToast();

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -32,15 +32,15 @@
                       Welcome back!
                     </h1>
 
-                    <v-alert
-                      class="my-5"
-                      closable
+                    <BaseAlert
                       v-model="showAlert"
+                      :type="alertType"
                       :icon="alertIcon"
                       :title="alertTitle"
-                      :text="alertText"
-                      :type="alertType"
-                    ></v-alert>
+                      class="my-5"
+                    >
+                      {{ alertText }}
+                    </BaseAlert>
 
                     <v-form>
                       <v-text-field
@@ -142,14 +142,15 @@
                       Create an Account
                     </h1>
 
-                    <v-alert
-                      closable
+                    <BaseAlert
                       v-model="showAlert"
+                      :type="alertType"
                       :icon="alertIcon"
                       :title="alertTitle"
-                      :text="alertText"
-                      :type="alertType"
-                    ></v-alert>
+                      class="mb-6"
+                    >
+                      {{ alertText }}
+                    </BaseAlert>
 
                     <v-form ref="regForm">
                       <v-row>
@@ -385,6 +386,7 @@ import { setToken } from "@/service/AccessToken";
 import { useUserStore } from "@/store/UserStore";
 import type { User } from "@/store/UserStore";
 import { onBeforeMount } from "vue";
+import BaseAlert from "@/components/Alerts/BaseAlert.vue";
 
 const userStore = useUserStore();
 

--- a/src/pages/RetailerRegistration.vue
+++ b/src/pages/RetailerRegistration.vue
@@ -30,8 +30,10 @@
                                         </v-col>
                                     </v-row>
                                 </v-container>
-                                <v-alert closable v-model="showAlert" :icon="alertIcon" :title="alertTitle"
-                                    :text="alertText" :type="alertType"></v-alert>
+                                <BaseAlert v-model="showAlert" :type="alertType" :icon="alertIcon" :title="alertTitle"
+                                    closable class="my-4">
+                                    {{ alertText }}
+                                </BaseAlert>
 
                                 <v-form ref="regForm">
                                     <v-row>
@@ -125,6 +127,7 @@ import PrivacyCard from "@/components/PrivacyCard.vue";
 import { setToken } from "@/service/AccessToken";
 import { useUserStore } from "@/store/UserStore";
 import type { User } from "@/store/UserStore";
+import BaseAlert from "@/components/Alerts/BaseAlert.vue";
 
 const userStore = useUserStore();
 

--- a/src/pages/ShareEvent.vue
+++ b/src/pages/ShareEvent.vue
@@ -19,9 +19,9 @@
                                 month: '2-digit',
                                 day: '2-digit',
                                 year: 'numeric',
-                            hour: '2-digit',
-                            minute: '2-digit',
-                            hour12: true
+                                hour: '2-digit',
+                                minute: '2-digit',
+                                hour12: true
                             }) }}
                         </p>
                     </v-card-text>
@@ -69,8 +69,7 @@
                         </v-col>
                     </v-row>
 
-                    <v-alert v-if="showSuccessAlert" type="success" class="mt-4" border="start" variant="tonal" closable
-                        @click:close="showSuccessAlert = false">
+                    <BaseAlert v-model="showSuccessAlert" type="success" border="start" variant="tonal" class="mt-4">
                         You’ve successfully joined this event! Visit the <strong>Events</strong> page to view it.
 
                         <v-row class="mt-3">
@@ -80,7 +79,7 @@
                                 </v-btn>
                             </v-col>
                         </v-row>
-                    </v-alert>
+                    </BaseAlert>
 
                     <!-- Dialog de login -->
                     <v-dialog v-model="showLoginDialog" width="460">
@@ -127,6 +126,7 @@
 <script setup>
 import { ref, onMounted, inject, computed } from "vue";
 import { useRoute, useRouter } from "vue-router";
+import BaseAlert from "@/components/Alerts/BaseAlert.vue";
 
 const router = useRouter();
 const route = useRoute();

--- a/src/pages/User.vue
+++ b/src/pages/User.vue
@@ -58,35 +58,42 @@
         <p class="user-name" style="font-weight: bold; font-size: 1.4rem">
           {{ user.user_name }}
 
-        <div class="d-none d-md-inline justify-center align-center">
-          <v-menu v-if="isFriend" open-on-hover>
-            <template v-slot:activator="{ props }">
-              <v-btn v-bind="props" icon="mdi-account-check" color="rgba(0, 0, 0, 0.0)" elevation="0"
-                size="small"></v-btn>
-            </template>
-            <!-- <v-list>
-            <v-list-item @click="removeFriend">
-              <v-list-item-icon>
-                <v-icon >mdi-account-remove</v-icon>
-              </v-list-item-icon>
-              <v-list-item-title>Remove Friend</v-list-item-title>
-            </v-list-item>
-          </v-list> -->
-          </v-menu>
+          <div class="d-none d-md-inline justify-center align-center">
+            <v-menu v-if="isFriend" open-on-hover>
+              <template v-slot:activator="{ props }">
+                <v-btn v-bind="props" icon="mdi-account-check" color="rgba(0, 0, 0, 0.0)" elevation="0"
+                  size="small"></v-btn>
+              </template>
+              <!-- <v-list>
+              <v-list-item @click="removeFriend">
+                <v-list-item-icon>
+                  <v-icon >mdi-account-remove</v-icon>
+                </v-list-item-icon>
+                <v-list-item-title>Remove Friend</v-list-item-title>
+              </v-list-item>
+            </v-list> -->
+            </v-menu>
 
-          <v-btn v-else icon="mdi-account-plus" color="rgba(0, 0, 0, 0.6)" elevation="3" size="small"
-            @click="addFriend"></v-btn>
-        </div>
+            <v-btn v-else icon="mdi-account-plus" color="rgba(0, 0, 0, 0.6)" elevation="3" size="small"
+              @click="addFriend"></v-btn>
+          </div>
 
-        <v-alert v-if="showAlert" type="success" class="custom-alert" text>
-          Friend request sent!
-        </v-alert>
+          <BaseAlert
+            v-model="showAlert"
+            type="success"
+            text
+            class="custom-alert"
+          >
+            Friend request sent!
+          </BaseAlert>
 
-        <v-alert v-if="showErrorAlert" type="error" class="custom-alert">
-          {{ errorMessage }}
-        </v-alert>
-
-
+          <BaseAlert
+            v-model="showErrorAlert"
+            type="error"
+            class="custom-alert"
+          >
+            {{ errorMessage }}
+          </BaseAlert>
         </p>
       </div>
     </v-card-text>
@@ -97,8 +104,6 @@
 
   <favorite-campaign-card />
 
-
-
 </template>
 
 <script lang="ts" setup>
@@ -106,6 +111,7 @@ import { inject, computed, ref } from "vue";
 import { useRoute } from "vue-router";
 import axios from "axios";
 import { useUserStore } from "@/store/UserStore";
+import BaseAlert from "@/components/Alerts/BaseAlert.vue";
 
 const assets = inject<string>("assets");
 const route = useRoute();


### PR DESCRIPTION
…nt in User.vue

- Import and register `BaseAlert.vue`
- Swap out `<v-alert>` instances for `<BaseAlert>` with `v-model`
- Simplify alert props (`type`, `icon`, `title`, `text`) and slot content
- Remove duplicated alert styling and leverage centralized component

This makes alert logic DRY and maintains consistent behavior across the app.