### PR TITLE
Add Brazilian Portuguese (pt_BR) translation

### DIFF
--- a/e2e/vue.spec.ts
+++ b/e2e/vue.spec.ts
@@ -1,8 +1,0 @@
-import { test, expect } from '@playwright/test';
-
-// See here how to get started:
-// https://playwright.dev/docs/intro
-test('visits the app root url', async ({ page }) => {
-  await page.goto('/');
-  await expect(page.locator('div.greetings > h1')).toHaveText('You did it!');
-})

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "@playwright/test": "^1.48.1",
         "@rushstack/eslint-patch": "^1.2.0",
         "@tsconfig/node20": "^20.1.4",
+        "@types/js-yaml": "^4.0.9",
         "@types/lodash-es": "^4.17.6",
         "@types/node": "^20.17.0",
         "@types/vue-the-mask": "^0.11.5",
@@ -69,6 +70,7 @@
         "eslint-plugin-playwright": "^2.0.0",
         "eslint-plugin-promise": "^6.4.0",
         "eslint-plugin-vue": "^9.29.0",
+        "js-yaml": "^5.2.3",
         "npm-run-all2": "^7.0.1",
         "postcss": "^8.4.20",
         "prettier": "^3.3.3",
@@ -2651,6 +2653,19 @@
         "vite": ">=3.2.7"
       }
     },
+    "node_modules/@modyfi/vite-plugin-yaml/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3225,6 +3240,13 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -6378,6 +6400,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint-config-vuetify/node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/eslint-config-vuetify/node_modules/minimatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
@@ -8672,16 +8717,26 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.3.tgz",
+      "integrity": "sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/jsesc": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build-only": "vite build",
     "type-check": "vue-tsc --build --force",
     "lint": "eslint . --fix",
-    "format": "prettier --write src/"
+    "format": "prettier --write src/",
+    "test:locales": "playwright test tests/locales/locale-integrity.spec.ts"
   },
   "dependencies": {
     "@babel/types": "^7.24.6",
@@ -59,6 +60,7 @@
     "@playwright/test": "^1.48.1",
     "@rushstack/eslint-patch": "^1.2.0",
     "@tsconfig/node20": "^20.1.4",
+    "@types/js-yaml": "^4.0.9",
     "@types/lodash-es": "^4.17.6",
     "@types/node": "^20.17.0",
     "@types/vue-the-mask": "^0.11.5",
@@ -76,6 +78,7 @@
     "eslint-plugin-playwright": "^2.0.0",
     "eslint-plugin-promise": "^6.4.0",
     "eslint-plugin-vue": "^9.29.0",
+    "js-yaml": "^5.2.3",
     "npm-run-all2": "^7.0.1",
     "postcss": "^8.4.20",
     "prettier": "^3.3.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,8 +23,11 @@ export default defineConfig({
   reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "http://localhost:5173/drunagor-helper/",
+    /* Base URL to use in actions like `await page.goto('/')`.
+       vite.config.mts does not set `base`, so the app is served from the root.
+       127.0.0.1 and not localhost: on Windows localhost resolves to ::1 first,
+       but vite listens on IPv4, so the readiness probe never succeeds. */
+    baseURL: "http://127.0.0.1:5173/",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
@@ -68,11 +71,17 @@ export default defineConfig({
     // },
   ],
 
-  /* Run your local dev server before starting the tests */
-  webServer: {
-    command: process.env.CI ? "vite preview --port 5173" : "vite dev",
-    port: 5173,
-    reuseExistingServer: !process.env.CI,
-    timeout: 5 * 1000,
-  },
+  /* Run your local dev server before starting the tests.
+     PW_NO_SERVER skips it, for suites that don't touch the browser
+     (see the `test:locales` script). */
+  webServer: process.env.PW_NO_SERVER
+    ? undefined
+    : {
+        command: process.env.CI
+          ? "vite preview --port 5173 --host 127.0.0.1"
+          : "vite dev --port 5173 --host 127.0.0.1",
+        url: "http://127.0.0.1:5173/",
+        reuseExistingServer: !process.env.CI,
+        timeout: 120 * 1000,
+      },
 });

--- a/src/language.ts
+++ b/src/language.ts
@@ -24,7 +24,7 @@ export async function loadLanguage(language: string) {
   let messages = await import(`@/locales/${language}/app.yaml`);
 
   if (messages.default === null) {
-    messages = await import("@/locales/en_US/keywords.yaml");
+    messages = await import("@/locales/en_US/app.yaml");
   }
 
   let keywords = await import(`@/locales/${language}/keywords.yaml`);

--- a/src/locales/en_US/app.yaml
+++ b/src/locales/en_US/app.yaml
@@ -90,6 +90,11 @@ label:
   shield: Shield
   back: Back
   success: Success
+  error: Error
+  class-abilities: Class Abilities
+  lifepoints: Life Points
+  heroes: My Heroes
+  select-card: Select Card
 text:
   input-token: Input your token here
   reset-state: This will reset all statuses and sequential adventure states from this campaign. Are you sure?
@@ -115,6 +120,10 @@ text:
   campaign-removed: Campaign removed
   campaign-removed-player: Remove Player
   share-campaign: Invite Player
+  no-outcomes: No outcomes selected
+  campaign-deleted-success: Campaign deleted successfully.
+  error-removing-campaign: Error removing campaign.
+  no-status: No status applied
 monster:
   wermuggdir: Wermuggdir
   abomination: Abomination
@@ -202,3 +211,8 @@ variant:
   standard: Standard
   alternate: Alternate
   complex: Complex (A / B)
+error:
+  user-not-logged: You must be signed in to create a campaign.
+  sku-not-found: No {type} product was found in your collection.
+  campaign-already-exists: You already have a campaign for this product.
+  campaign-creation-failed: The campaign could not be created. Please try again.

--- a/src/locales/pt_BR/app.yaml
+++ b/src/locales/pt_BR/app.yaml
@@ -1,1 +1,218 @@
----
+randomizer:
+  random-monster: Monstro aleatório
+  exclude-current-monster: Excluir o personagem sorteado atualmente
+  enabled-content: Conteúdo habilitado
+  white: Branco
+  gray: Cinza
+  black: Preto
+  commander: Comandante
+  overlord: Suserano
+  error:
+    no-other-monster-available: Não há outros monstros disponíveis.
+    no-other-commander-available: Não há outros comandantes / suseranos disponíveis.
+label:
+  equipment-skills: Equipamento & Habilidades
+  remove-campaign: Remover campanha
+  new-campaign: Nova campanha
+  export-campaign: Exportar campanha
+  save-campaign-put: Salvar Campanha
+  copy-to-clipboard: Copiar para a área de transferência
+  import-campaign: ' Importar campanha'
+  sequential-adventure: Começar a Jogar
+  camp-phase: redefinir estados
+  remove-hero: Remover herói
+  add-hero: Adicionar herói
+  campaigns: Campanhas
+  campaign: Campanha
+  campaign-log: Registro da Campanha
+  'yes': Sim
+  'no': Não
+  import: Importar
+  close: Fechar
+  cancel: Cancelar
+  filter-by-proficiency: Filtrar por proficiência
+  weapon: Arma
+  off-hand: Mão Secundária
+  armor: Armadura
+  trinket: Adorno
+  bag-slot: Espaço da Mochila
+  skills: Habilidades
+  stash: Depósito
+  nothing-found: Nada encontrado
+  equipment: Equipamento
+  dungeon-role: Função na Masmorra
+  melee: Corpo a corpo
+  ranged: À distância
+  agility: Agilidade
+  wisdom: Sabedoria
+  level: Nível
+  yellow: Amarelo
+  red: Vermelho
+  blue: Azul
+  green: Verde
+  dwarf: Anão
+  human: Humano
+  elf: Elfo
+  draconian: Draconiano
+  orc: Orc
+  vampire: Vampiro
+  halfling: Halfling
+  efreet: Efrit
+  succubus: Súcubo
+  valkyrie: Valquíria
+  azurean: Azureano
+  mage: Mago
+  sorcerer: Feiticeiro
+  shadow-knight: Cavaleiro das Sombras
+  paladin: Paladino
+  warrior: Guerreiro
+  assasin: Assassino
+  bard: Bardo
+  ranger: Patrulheiro
+  cleric: Clérigo
+  barbarian: Bárbaro
+  druid: Druida
+  monk: Monge
+  swordmage: Espadamago
+  warlord: Senhor da Guerra
+  necromancer: Necromante
+  shaman: Xamã
+  mystics: dos Místicos
+  strength: da Força
+  devotion: da Devoção
+  cunning: da Astúcia
+  nature: da Natureza
+  resources: Recursos
+  focus: Foco
+  fury: Fúria
+  fruit-of-life: Fruto da Vida
+  ki: KI
+  shield: Escudo
+  back: Voltar
+  success: Sucesso
+  error: Erro
+  class-abilities: Aptidões de Classe
+  lifepoints: Pontos de Vida
+  heroes: Meus Heróis
+  select-card: Selecionar Carta
+text:
+  input-token: Insira seu token aqui
+  reset-state: Isto irá redefinir todos os estados e o progresso da aventura sequencial desta campanha. Tem certeza?
+  cannot-be-restored: Isto não pode ser desfeito. Tem certeza?
+  copy-this-token: Copie este token para importar sua campanha em outro dispositivo
+  select-action-cube-color: Selecione a cor do cubo de ação
+  curse-cubes: Cubos de Maldição
+  trauma-cubes: Cubos de Trauma
+  path-of: Caminho
+  add-or-remove-status: Adicionar ou remover estado
+  add-or-remove-unfolding: Adicionar ou remover desdobramento
+  add-or-remove-outcome: Adicionar ou remover desfecho
+  add-or-remove-follower: Adicionar ou remover seguidor
+  add-or-remove-stashed-items: Adicionar ou remover itens do depósito
+  select-aura: Selecione a aura
+  aura-info: A aura é removida quando você recebe um cubo de trauma ou outra aura.
+  outcome-info: Permanecem em efeito durante toda a campanha, a menos que algum outro efeito os altere.
+  status-info: Os estados são removidos durante a fase de acampamento.
+  number-of-runes: 'Número de runas:'
+  party-name: 'Nome do grupo:'
+  no-resources: Sem recursos
+  campaign-imported: Campanha importada
+  campaign-removed: Campanha removida
+  campaign-removed-player: Remover Jogador
+  share-campaign: Convidar Jogador
+  no-outcomes: Nenhum desfecho selecionado
+  campaign-deleted-success: Campanha excluída com sucesso.
+  error-removing-campaign: Erro ao remover a campanha.
+  no-status: Nenhum estado aplicado
+monster:
+  wermuggdir: Wermuggdir
+  abomination: Abominação
+  archon: Arconte
+  bane: Bane
+  bone-reaper: Ceifador de Ossos
+  commander-doctor: Doutor
+  commander-flinch: Flinch
+  commander-hexer: Enfeitiçador
+  commander-horde: Horda
+  commander-hunter: Caçador
+  commander-ox: Boi
+  commander-thern: Thern
+  commander-twin: Gêmeos
+  commander-spawn: Progênie
+  commander-witch: Bruxa
+  corrupted-farmer: Fazendeiro Corrompido
+  corrupted-worm: Verme Corrompido
+  death-messenger: Mensageiro da Morte
+  demon-lord: Senhor Demônio
+  dream-titan: Titã dos Sonhos
+  executioner: Executor
+  faceless-conjurer: Conjurador Sem Rosto
+  fallen-sisters: Irmãs Caídas
+  fell-asteris: Fell Asteris
+  gorgon-hexer: Enfeitiçador Górgona
+  gorgoness-witch: Bruxa Górgona
+  gremlin-horde: Horda de Gremlins
+  grim-doctor: Doutor Sinistro
+  hellish-flayer: Esfolador Infernal
+  hellspawn-brute: Bruto Prole-Infernal
+  lady-claw: Dama-Garra
+  nagian-hunter: Caçador Nagiano
+  night-stalker: Predador Noturno
+  ravager: Devastador
+  rotten-flesh: Carne Apodrecida
+  scout-of-darkness: Batedor das Trevas
+  shadow-cultist: Cultista das Sombras
+  shadow-guardian: Guardião das Sombras
+  shadow-knight: Cavaleiro das Sombras
+  shadow-mistress: Senhora das Sombras
+  shadow-pain: Dor das Sombras
+  shadow-vampire: Vampiro das Sombras
+  shadow-witch: Bruxa das Sombras
+  skeleton-archer: Arqueiro Esqueleto
+  skeleton-knight: Cavaleiro Esqueleto
+  walking-horror: Horror Ambulante
+menu:
+  menu: Menu
+  random-monster: Monstro aleatório
+  campaign: Campanha
+  keyword: Palavra-chave
+  settings: Conteúdo
+language:
+  english: Inglês
+  german: Alemão
+  spanish: Espanhol
+  french: Francês
+  italian: Italiano
+  portuguese: Português
+  polish: Polonês
+configuration:
+  language: Idioma
+  enabled-variant: Variante habilitada
+  monster-content: Conteúdo de monstros
+  hero-content: Conteúdo de heróis
+  error:
+    atleast-one-selected: Ao menos uma opção deve ser selecionada.
+content:
+  apocalypse: Apocalypse
+  awakenings: Awakenings
+  core: Base
+  desert-of-hellscar: Deserto de Hellscar
+  fallen-sisters: Fallen Sisters
+  handuriel: Handuriel
+  hero-pack-1: Hero Pack 1
+  lord-wrath: Lordwrath
+  lorien: Lorien
+  monster-pack-1: Monster Pack 1
+  rise-of-the-undead-dragon: Ascensão do Dragão Morto-Vivo
+  spoils-of-war: Espólios de Guerra
+  the-ruin-of-luccanor: A Ruína de Luccanor
+  the-shadow-world: O Mundo das Sombras
+variant:
+  standard: Padrão
+  alternate: Alternativa
+  complex: Complexa (A / B)
+error:
+  user-not-logged: Você precisa estar conectado para criar uma campanha.
+  sku-not-found: Nenhum produto {type} foi encontrado na sua coleção.
+  campaign-already-exists: Você já tem uma campanha para este produto.
+  campaign-creation-failed: Não foi possível criar a campanha. Tente novamente.

--- a/src/locales/pt_BR/campaign.yaml
+++ b/src/locales/pt_BR/campaign.yaml
@@ -1,1 +1,1150 @@
----
+outcome:
+  underkeep:
+    campaign:
+      - id: a-couriers-job
+        name: Atacante
+        effect: ''
+      - id: adamant
+        name: Controlador
+        effect: ''
+      - id: a-hideous-act
+        name: Líder
+        effect: ''
+      - id: a-lovers-request
+        name: Defensor
+        effect: ''
+      - id: corrupted-hero
+        name: Suporte
+        effect: ''
+  core:
+    campaign:
+      - id: a-couriers-job
+        name: Trabalho de mensageiro
+        effect: ''
+      - id: adamant
+        name: Inflexível
+        effect: ''
+      - id: a-hideous-act
+        name: Um ato hediondo
+        effect: ''
+      - id: a-lovers-request
+        name: Pedido de um amante
+        effect: ''
+      - id: corrupted-hero
+        name: Herói corrompido
+        effect: ''
+      - id: curse-breaker
+        name: Quebra-maldição
+        effect: ''
+      - id: dynamic-duo
+        name: Dupla dinâmica
+        effect: ''
+      - id: gentle-dismissal
+        name: Dispensa gentil
+        effect: ''
+      - id: guardians-curse
+        name: Maldição do guardião
+        effect: Enquanto você tiver a Maldição do Guardião, não pode desequipar o Bracelete Amaldiçoado.
+      - id: humbled
+        name: Humilhado
+        effect: ''
+      - id: lovebirds-reunited
+        name: Pombinhos reunidos
+        effect: ''
+      - id: relic-breaker
+        name: Quebra-relíquias
+        effect: ''
+      - id: sowing-winds
+        name: Semeando ventos
+        effect: ''
+      - id: storyteller
+        name: Contador de histórias
+        effect: ''
+      - id: unbroken
+        name: Inquebrável
+        effect: ''
+    storyrecord: []
+  apocalypse:
+    campaign:
+      - id: bitten
+        name: Mordido
+        effect: Sempre que você tomar uma Ação de Recuperação, sofre ATORDOAR. Este ATORDOAR ignora qualquer tipo de imunidade que você tenha, já que representa sua dificuldade em lidar com suas ações após sofrer um ferimento tão grave e não um transtorno mental devido a trauma físico.
+      - id: deep-wound
+        name: Ferida Profunda
+        effect: Você pode manter um Cubo de Trauma a menos
+    storyrecord:
+      - id: a-good-deal
+        name: Um Bom Acordo
+        effect: ''
+      - id: beautiful-lie
+        name: Bela Mentira
+        effect: ''
+      - id: broken
+        name: Quebrado
+        effect: ''
+      - id: exquisite-friends
+        name: Amigos Refinados
+        effect: ''
+      - id: friendly-advice
+        name: Conselho Amigável
+        effect: ''
+      - id: gal-s-fate
+        name: Destino da Gal
+        effect: ''
+      - id: hellscarian-ally
+        name: Aliado de Hellscar
+        effect: ''
+      - id: hellscarian-enemy
+        name: Inimigo de Hellscar
+        effect: ''
+      - id: hero-s-journey
+        name: Jornada do Herói
+        effect: ''
+      - id: humbled
+        name: Humilhado
+        effect: ''
+      - id: impostor
+        name: Impostor
+        effect: ''
+      - id: insured-trip
+        name: Viagem Segura
+        effect: ''
+      - id: late-guests
+        name: Convidados Atrasados
+        effect: ''
+      - id: long-live
+        name: Vida Longa!
+        effect: ''
+      - id: luccanor-s-redemption
+        name: Redenção de Luccanor
+        effect: ''
+      - id: misery-ended
+        name: Miséria Encerrada
+        effect: ''
+      - id: mob-justice
+        name: Justiça da Turba
+        effect: ''
+      - id: no-quarter-given
+        name: Sem Piedade
+        effect: ''
+      - id: possessed
+        name: Possuído
+        effect: ''
+      - id: scarce-provisions
+        name: Provisões Escassas
+        effect: ''
+      - id: shattered-dreams
+        name: Sonhos Despedaçados
+        effect: ''
+      - id: strong-bonds
+        name: Laços Fortes
+        effect: ''
+      - id: the-duke-s-betrayal
+        name: A Traição do Duque
+        effect: ''
+      - id: the-earl-of-blackriver
+        name: O Conde de Blackriver
+        effect: ''
+      - id: triumphant
+        name: Triunfante
+        effect: ''
+      - id: truthful
+        name: Verdadeiro
+        effect: Heróis acertam com Ataque de Arma e têm sucesso em Testes de Habilidade sempre que rolarem 1 no d20. Cada Herói que também tem uma Habilidade de Classe que transforma suas rolagens naturais de 1 em acertos de Ataque de Arma também obtém um Acerto Crítico nesses ataques.
+      - id: umbralian-ally
+        name: Aliado Umbraliano
+        effect: ''
+      - id: umbralian-enemy
+        name: Inimigo Umbraliano
+        effect: ''
+      - id: unbroken
+        name: Inquebrável
+        effect: ''
+      - id: uncertain-journey
+        name: Jornada Incerta
+        effect: ''
+      - id: wounded-eye
+        name: Olho Ferido
+        effect: ''
+      - id: wounded-paw
+        name: Pata Ferida
+        effect: ''
+  awakenings:
+    campaign:
+      - id: ancient-book
+        name: Livro Antigo
+        effect: ''
+      - id: counting-kittens
+        name: Contando Gatinhos
+        effect: ''
+      - id: defenders-fate
+        name: Destino do Defensor
+        effect: ''
+      - id: drinking-pal
+        name: Colega de Bebida
+        effect: ''
+      - id: entangled
+        name: Enredado
+        effect: ''
+      - id: farewell
+        name: Despedida
+        effect: ''
+      - id: full-house
+        name: Casa Cheia
+        effect: ''
+      - id: minervas-diary
+        name: Diário da Minerva
+        effect: ''
+      - id: pirates-gift
+        name: Presente do Pirata
+        effect: ''
+      - id: promised-reward
+        name: Recompensa Prometida
+        effect: ''
+      - id: reunited
+        name: Reunidos
+        effect: ''
+      - id: selfish
+        name: Egoísta
+        effect: ''
+      - id: selfless
+        name: Altruísta
+        effect: ''
+      - id: threats-or-treats
+        name: Ameaças ou Guloseimas
+        effect: ''
+      - id: untangled
+        name: Desenredado
+        effect: ''
+      - id: watcher
+        name: Vigilante
+        effect: ''
+    storyrecord: []
+auras:
+  core:
+    campaign:
+      - id: blessing-of-good-fortune
+        name: Bênção da boa sorte
+        effect: Sempre que qualquer Herói Gastar um CA para qualquer efeito que não seja FADIGA (como ganhar uma Ação de Movimento adicional em um turno, por exemplo), ele também recupera 1 CA.
+      - id: blessing-of-the-guardian
+        name: Bênção do guardião
+        effect: Sempre que qualquer Herói Gastar um CA para qualquer efeito que não seja FADIGA (como ganhar uma Ação de Movimento adicional em um turno, por exemplo), ele também ganha ESCUDO 2.
+      - id: bloodlust
+        name: Sede de sangue
+        effect: 'Sempre que você matar um Monstro durante seu turno: Depois de resolver a Ação atual, você pode tomar uma Ação com Cubo adicional. Esta habilidade só pode ser ativada uma vez por turno.'
+      - id: bonding
+        name: Vínculo
+        effect: Sempre que um Companheiro terminar seu turno adjacente a você, ele ganha ESCUDO 4.
+      - id: boon-of-empathy
+        name: Bênção da empatia
+        effect: Como uma Ação Menor, você pode pegar um Cubo de Trauma de um Herói que esteja adjacente a você e colocá-lo em seu painel. Receber um Cubo de Trauma desta forma não encerra os efeitos desta Bênção.
+      - id: boon-of-gratitude
+        name: Bênção da gratidão
+        effect: PREVENIR ganha um bônus de +1
+      - id: brave-hearted
+        name: Coração corajoso
+        effect: A Escuridão sempre trata você como o Herói Mais Forte (a menos que você já esteja sobre a Escuridão) e você não recebe dano da Escuridão.
+      - id: clear-conscious
+        name: Consciência limpa
+        effect: 'Sempre que você matar uma criatura com um ataque (Mágico ou de Arma), você ganha: EM SI, PURIFICAR 1.'
+      - id: cold-hearted
+        name: Coração frio
+        effect: A Escuridão sempre trata você como o Herói Mais Forte (a menos que você já esteja sobre a Escuridão) e, enquanto você estiver sobre a Escuridão, sempre que acertar um Monstro com um Ataque de Arma ou Ataque Mágico pela primeira vez durante seu turno, esse ataque causa +2 de dano.
+      - id: disdained
+        name: Desprezado
+        effect: Sempre que você tomar uma Ação de Recuperação, sofre FADIGA 1 após resolvê-la.
+      - id: determined
+        name: Determinado
+        effect: Você é imune a LENTO e ATORDOAR.
+      - id: grandeur
+        name: Grandeza
+        effect: 'Sempre que qualquer Herói obtiver um Acerto Crítico, ele ganha: EM SI, PURIFICAR 2.'
+      - id: hellbent
+        name: Obstinado
+        effect: Sempre que qualquer Herói obtiver um Acerto Crítico, o ataque ganha +1 DANO (não dobre por causa do crítico) por Cubo de Maldição que aquele Herói estiver mantendo.
+      - id: inspiring-leadership
+        name: Liderança inspiradora
+        effect: Todos os Heróis do grupo obtêm um Acerto Crítico em vez de uma Falha Crítica sempre que rolarem 1 no d20.
+      - id: intoxicated
+        name: Intoxicado
+        effect: Sempre que você tomar uma Ação de Recuperação, sofre VENENO 4.
+      - id: murderous-intent
+        name: Intenção assassina
+        effect: 'Sempre que você matar uma criatura com um Ataque (Mágico ou de Arma), você ganha: EM SI, FOCO 1.'
+      - id: over-the-edge
+        name: No limite
+        effect: 'Sempre que qualquer Herói obtiver um Acerto Crítico, ele ganha: EM SI, FOCO 1.'
+      - id: soulmates-reunited
+        name: Almas gêmeas reunidas
+        effect: Sempre que você rolar 1 no d20, obtém um Acerto Crítico em vez de uma Falha Crítica e ganha FOCO 2.
+      - id: spellshock
+        name: Choque mágico
+        effect: Sempre que você tomar uma Reação, sofre FADIGA 1.
+      - id: true-hearted-blessing
+        name: Bênção do coração verdadeiro
+        effect: Sempre que qualquer Herói Gastar um CA para qualquer efeito que não seja FADIGA (como ganhar uma Ação de Movimento adicional em um turno, por exemplo), ele também ganha FOCO 1.
+      - id: well-meaning
+        name: Bem intencionado
+        effect: Sempre que você usar um efeito de PURIFICAR em qualquer Herói, aquele Herói também pode Recuperar até um Cubo de Ação.
+    storyrecord: []
+  apocalypse:
+    campaign:
+      - id: brute-force
+        name: Força Bruta
+        effect: 'Como uma Ação Menor, você pode Gastar 1 CA para: EM SI, FORTALECER.'
+      - id: burden-of-guilt
+        name: Fardo da Culpa
+        effect: 'Sempre que você tomar uma Ação de Recuperação: Você sofre INTIMIDAR 4. Este INTIMIDAR ignora qualquer tipo de imunidade que seu Herói possa ter.'
+      - id: dried-tears
+        name: Lágrimas Secas
+        effect: 'Sempre que você tomar uma Ação de Recuperação: Você recebe PURIFICAR 1.'
+      - id: grievous-wound
+        name: Ferida Grave
+        effect: 'Sempre que você tomar uma Ação de Recuperação: Você sofre SANGRAMENTO 4. Este SANGRAMENTO ignora qualquer tipo de imunidade que seu Herói possa ter.'
+      - id: helpful
+        name: Prestativo
+        effect: 'Sempre que você derrotar um Monstro (você deve ser aquele a desferir o golpe final): EM SI, INSPIRAR.'
+      - id: inobtrusive
+        name: Discreto
+        effect: Um Monstro não pode atacar você a menos que você ou um NPC de seu grupo (seus Mascotes incluídos) já os tenham atacado ou os tenham afetado com um efeito de qualquer tipo.
+      - id: justiciar
+        name: Justiceiro
+        effect: Sempre que um Herói tomar uma Ação de Recuperação, após resolvê-la, esse Herói recebe PURIFICAR 1 ou FOCO 1.
+      - id: last-stand
+        name: Último Suporte
+        effect: Sempre que você fosse cair a 0 de Vida, faça um Teste de Habilidade de Força (amarelo) de Dificuldade 11. Cada cubo Corpo a corpo que você tem concede um bônus de +2 à sua rolagem. Além disso, cada Estado “Esforço” que você tem anotado em seu Registro de Campanha carrega uma penalidade de -5 à sua rolagem. Se tiver sucesso, você cai a 1 de Vida e anota um Estado “Esforço” em seu Registro de Campanha. Se falhar, você é Nocauteado normalmente (o que fará com que esta Aura seja removida de seu Registro de Campanha).
+      - id: like-water
+        name: Como Água
+        effect: 'Como uma Ação Menor, você pode Gastar 1 CA para: EM SI, ESCUDO 4.'
+      - id: overwhelming-power
+        name: Poder Avassalador
+        effect: 'Como uma Ação Menor você pode Gastar 1 CA para: Alcance 1, Ataque Mágico de 4 DANO.'
+      - id: peace-broker
+        name: Mediador de Paz
+        effect: Sempre que um Herói tomar uma Ação de Recuperação, após resolvê-la, esse Herói ganha ESCUDO 4.
+      - id: steadfast
+        name: Firme
+        effect: Sempre que um Herói tomar uma Ação de Recuperação, esse Herói ganha FOCO 2.
+      - id: stern
+        name: Severo
+        effect: 'Sempre que um Monstro atacar você: antes de sofrer qualquer dano, você ganha ESCUDO 1.'
+    storyrecord: []
+  awakenings:
+    campaign:
+      - id: ancient-spell
+        name: Feitiço Antigo
+        effect: No início de seu turno, você ganha ESCUDO 1.
+      - id: bastion
+        name: Bastião
+        effect: Você não pode ser PISOTEADO por Devastadores Vis.
+      - id: blessing-of-prosperity
+        name: Bênção da Prosperidade
+        effect: Sempre que você comprar uma carta de Baú, compre uma carta de Baú adicional e escolha uma dentre elas para manter.
+      - id: calm-mind
+        name: Mente Calma
+        effect: Sempre que qualquer Herói receber um efeito de PURIFICAR, ele RECUPERA 2 DE VIDA.
+      - id: city-hero
+        name: Herói da Cidade
+        effect: Sempre que você tomar uma Ação de Recuperação, faça um Teste de Habilidade de Sabedoria (azul) de Dificuldade 13. Cada cubo de Sabedoria que você tem lhe dá um bônus de +2 à sua rolagem. Se Suceder, evite a Penalidade de Cubo de Maldição que você receberia. Caso contrário, sofre a Penalidade de Cubo de Maldição normalmente.
+      - id: critical-movements
+        name: Movimentos Críticos
+        effect: Ataques de Arma que você fizer ganham AGUÇADO.
+      - id: dour
+        name: Sombrio
+        effect: Se nenhum aliado estiver adjacente a você, seus Ataques de Arma ganham um bônus de +2 no ACERTO e seus Ataques Mágicos ganham um bônus de +1 DANO.
+      - id: dragon-s-breath
+        name: Sopro do Dragão
+        effect: Sempre que você tomar uma Ação de Recuperação, você arrota fogo, pegando um Cubo de Maldição adicional (num total de dois) e escolhendo uma área (quadrado azul) dentro do Alcance 1 para infligir QUEIMADURA 4 em cada Personagem nela. Cada um dos outros Heróis que não foi pego pelo fogo acha isso hilário e recebe um marcador de INSPIRAÇÃO.
+      - id: fainted-memoir
+        name: Memória Vacilante
+        effect: Sempre que um Herói tomar uma Ação de Recuperação, ele ganha um marcador de INSPIRAÇÃO e recebe FORTALECER.
+      - id: fighting-back
+        name: Contra-Ataque
+        effect: Sempre que qualquer Herói tomar uma Interrupção ou uma Reação para responder a um ataque, o atacante sofre 1 de dano não prevenível.
+      - id: fighting-spirit
+        name: Espírito de Luta
+        effect: 'Sempre que um Monstro for morto: Em Si, Recupere 1 de Vida'
+      - id: gold-digger
+        name: Garimpeiro
+        effect: Sempre que você vasculhar um Baú ou pegar um Saque, você compra as duas cartas do topo do baralho de Baú, escolhe uma delas para manter e descarta a outra em vez de apenas comprar a carta do topo.
+      - id: heroic-resolution
+        name: Resolução Heroica
+        effect: Sempre que um Herói fosse ser Nocauteado pelo dano de um ataque, ele pode fazer um Teste de Habilidade de Força (amarelo) de dificuldade 13. Cada cubo Corpo a corpo que ele tem lhe dá um bônus de +2 à sua rolagem. Se tiver sucesso, ele cai a 1 de Vida em vez disso. Se falhar, ele é Nocauteado normalmente.
+      - id: hurry-up
+        name: Depressa
+        effect: Sempre que qualquer Herói Gastar 1 CA para tomar uma Ação de Movimento Adicional em um turno, essa Ação de Movimento Adicional ganha +1 MOVIMENTO e PISOTEAR 2.
+      - id: inspired
+        name: Inspirado
+        effect: Uma vez por turno e apenas durante seu turno, você pode rerrolar um d20 que acabou de rolar se não gostou do resultado.
+      - id: inspiring-presence
+        name: Presença Inspiradora
+        effect: Ataques de Arma feitos por qualquer Herói dentro do Alcance 1 dele ganham um Bônus de +1 PARA ACERTAR.
+      - id: kitten-chaser
+        name: Perseguidor de Gatinhos
+        effect: Sempre que você Gastar 1 CA para tomar uma Ação de Movimento adicional (isto não inclui nenhuma Habilidade de Agilidade ou sua Ação de Movimento Grátis), você ganha FOCO 2.
+      - id: lone-wolf
+        name: Lobo Solitário
+        effect: Enquanto nenhum outro aliado estiver adjacente a você (Heróis, Camaradas e Mascotes são aliados), sempre que você tomar uma Interrupção ou uma Reação contra um ataque ou ameaça gerada por um Monstro, o monstro atacante sofre 2 de DANO não prevenível.
+      - id: moves-like-jagger
+        name: Se Move Como Jagger
+        effect: Sempre que você tomar uma Reação, também tenha como Alvo Outro Herói, INSPIRAR.
+      - id: obscure-lore
+        name: Saber Obscuro
+        effect: Efeitos de FOCO que você conjurar ganham um Bônus de +1.
+      - id: prohibition
+        name: Proibição
+        effect: Cada Herói pode, uma vez por turno, pegar um Cubo de Maldição para rerrolar um d20 que acabou de rolar cujo resultado não gostou.
+      - id: protector
+        name: Protetor
+        effect: Efeitos de PREVENIR que qualquer Herói conjurar ganham um BÔNUS de +1.
+      - id: reckless-revenge
+        name: Vingança Imprudente
+        effect: Sempre que você perder 1 ou mais de Vida, ganha FOCO 1 (sofrer dano causa perda de vida).
+      - id: sentinel
+        name: Sentinela
+        effect: 'Sempre que um Personagem aliado adjacente a você for atacado, como uma Interrupção, você pode Gastar 1 Cubo de Ação para fazer um Ataque de Arma de +0 ACERTO contra o Monstro que o está atacando, se esse Monstro também estiver no Alcance de sua arma. Se esse Monstro for derrotado por seu ataque, cancele seu ataque atual: ele não causará dano a nenhum de seus alvos. NOTA: Se você tomar uma Interrupção contra o ataque de um Monstro, não pode também tomar Reações contra nenhuma ameaça gerada por esse mesmo ataque.'
+      - id: setting-sun-s-blessing
+        name: Bênção do Sol Poente
+        effect: 'Heróis acertam com Ataque de Arma e têm sucesso com Testes de Habilidade sempre que rolarem 1 no d20. Além disso, sempre que um Herói conjurar um efeito de Ataque Mágico, ele deve rolar o d20: se rolar 16+, esse Ataque Mágico é um Acerto Crítico (causa o dobro do dano que normalmente causaria).'
+      - id: sisters-bond
+        name: Laço de Irmãs
+        effect: Sempre que outro Herói dentro do Alcance 1 fosse sofrer dano ou receber um Cubo de Maldição, você pode sofrer esse dano ou receber esse Cubo de Maldição em seu lugar. Se o fizer, sente-se recompensado e ganha um marcador de INSPIRAÇÃO.
+      - id: taunt
+        name: Provocação
+        effect: 'Sempre que seus aliados no Alcance 1 forem atacados, você pode sofrer FADIGA 1 para: COBRIR o ALIADO alvo (se dois ou mais aliados estiverem sendo atacados ao mesmo tempo, você só pode Cobrir um deles). Cobrir um Alvo desta forma não requer ação e é feito na velocidade de uma Interrupção, mas não é considerado uma Interrupção.'
+      - id: throat-slitter
+        name: Cortador de Gargantas
+        effect: 'Sempre que você desferir um Golpe Mortal: você ganha FOCO 1. Este efeito só pode ser ativado uma vez por turno.'
+      - id: truthful
+        name: Verdadeiro
+        effect: Você só recebe um Cubo de Maldição ao tomar Ações de Recuperação.
+      - id: uncertain-readings
+        name: Leituras Incertas
+        effect: Heróis podem pegar um Cubo de Maldição e sofrer FRÁGIL para transformar um Teste de Precisão que acabaram de errar em um sucesso.
+      - id: valorous-party
+        name: Grupo Valoroso
+        effect: Sempre que um Herói obtiver um Acerto Crítico, esse Herói pode ganhar à sua escolha FOCO 1 ou PURIFICAR 1
+      - id: vision-beyond-reach
+        name: Visão Além do Alcance
+        effect: Todos os Ataques de Arma à Distância que você fizer e efeitos à Distância que você conjurar ganham +1 de ALCANCE. Então, você pode continuar a jogar a Aventura
+    storyrecord: []
+statuses:
+  underkeep:
+    campaign:
+      - id: blackriver-survivors
+        name: Sobreviventes de Blackriver
+      - id: blackriver-monsters
+        name: Monstros de Blackriver
+  underkeep2:
+    campaign:
+      - id: boil-fast
+        name: Fervura Rápida
+      - id: ferment-fast
+        name: Fermentação Rápida
+      - id: boil-slow
+        name: Fervura Lenta
+      - id: ferment-slow
+        name: Fermentação Lenta
+  core:
+    campaign:
+      - id: a-cooperative-approach
+        name: Uma abordagem cooperativa
+        effect: Sempre que um Herói vasculhar um Baú, ele pode comprar uma carta adicional e escolher uma das duas que comprou para manter. Ele deve embaralhar a outra carta de volta no baralho.
+      - id: a-friendly-approach
+        name: Uma abordagem amigável
+        effect: Sempre que qualquer Herói resolver um efeito com a palavra-chave 'EM SI', ele pode escolher outro personagem que esteja adjacente a ele como seu alvo em vez de si mesmo.
+      - id: aggressive-approach
+        name: Abordagem agressiva
+        effect: 'Como uma Ação Menor, você pode: EM SI, MALDIÇÃO 1 para desinvocar uma Assombração do Rei Morto-Vivo.'
+      - id: a-man-s-best-friend
+        name: O melhor amigo do homem
+        effect: ''
+      - id: a-mysterious-click
+        name: Um clique misterioso
+        effect: ''
+      - id: apathetic
+        name: Apático
+        effect: ''
+      - id: a-suspicious-approach
+        name: Uma abordagem suspeita
+        effect: Todos os Baús são considerados seguros e os Heróis não precisam rolar o dado de Armadilha ao vasculhá-los.
+      - id: battlefield-medic
+        name: Médico de campo
+        effect: 'Como uma Ação com Cubo, você pode: Gastar 1 CA enquanto adjacente a um Herói Nocauteado para remover o Cubo de Trauma que ele acabou de receber de seu painel (esta ação não pode remover um Cubo de Trauma de um Herói depois que ele recuperou o fôlego).'
+      - id: beheaded
+        name: Decapitado
+        effect: ''
+      - id: blessed-source
+        name: Fonte abençoada
+        effect: Você não recebe nenhum Cubo de Maldição ao tomar uma Ação de Recuperação.
+      - id: bloodlust
+        name: Sede de sangue
+        effect: Sempre que você matar um Monstro durante seu turno, depois de resolver a Ação atual, você pode tomar uma Ação com Cubo adicional. Este efeito só pode ser ativado uma vez por turno. Caso contrário, se nenhum Herói o tiver, você ganha FOCO 2.
+      - id: blue-flame
+        name: Chama azul
+        effect: Você não sofre dano da Escuridão.
+      - id: bookworm
+        name: Rato de biblioteca
+        effect: Sempre que você tomar uma Ação de Recuperação durante seu turno, você pode recuperar uma carta de Pergaminho da pilha de descarte do baralho de Baú e usá-la imediatamente. Isso não conta como uma Ação Menor de “Usar Item Consumível”. Se o fizer, após resolver aquela carta, embaralhe-a de volta no baralho de Baú em vez de colocá-la novamente na pilha de descarte.
+      - id: bullied
+        name: Intimidado
+        effect: Sempre que você rolar 5 ou menos no d20, você obtém uma falha crítica.
+      - id: cautious
+        name: Cauteloso
+        effect: 'Sempre que um Herói sem o Estado ''Alertado'' fosse ser nocauteado, esse Herói pode: EM SI, MALDIÇÃO 1. Se o fizer, deve anotar o Estado ''Alertado'' em seu Registro de Campanha e cair a 1 de Vida em vez disso.'
+      - id: certainty-1
+        name: Certeza
+        effect: ''
+      - id: certainty-2
+        name: Certeza
+        effect: ''
+      - id: certainty-3
+        name: Certeza
+        effect: ''
+      - id: challenger
+        name: Desafiante
+        effect: 'Sempre que você sofrer 4 ou mais de dano de um ataque (dano sofrido é calculado após PREVENIR): RETALIAR 2.'
+      - id: cicadas-chant
+        name: Canto da cigarra
+        effect: ''
+      - id: curiosity-1
+        name: Curiosidade
+        effect: ''
+      - id: curiosity-2
+        name: Curiosidade
+        effect: ''
+      - id: curiosity-3
+        name: Curiosidade
+        effect: ''
+      - id: curse
+        name: Maldição
+        effect: ''
+      - id: cursebreaker
+        name: Quebra-maldição
+        effect: ''
+      - id: deep-understanding
+        name: Compreensão profunda
+        effect: 'Sempre que qualquer Herói escolher uma Interação, ele pode: EM SI, MALDIÇÃO 1. Se o fizer, pode desfazer a Interação que acabou de ler e escolher outra Interação daquela mesma cena novamente. Ele só pode usar esta habilidade uma vez por Interação, e a Interação que é revertida desta forma se torna disponível novamente.'
+      - id: double-check
+        name: Verificação dupla
+        effect: 'Como uma Ação Menor, você pode: EM SI, MALDIÇÃO 1 para remover um tile de Escuridão em que você esteja sobre e ganhar FOCO 1.'
+      - id: embarrassed
+        name: Envergonhado
+        effect: Você só pode usar cubos Verdes e Azuis para Ativar suas Habilidades que têm um Espaço de CA de quatro cores.
+      - id: emeraldblessing
+        name: Bênção esmeralda
+        effect: 'Seus Ataques Mágicos ganham VENENO 2 e seus Ataques de Arma ganham ''Sempre que você Rolar 16+: este ataque ganha VENENO 2'''
+      - id: fair-and-square
+        name: Justo e reto
+        effect: Você obtém um Acerto Crítico sempre que rolar 4 ou 16 no d20.
+      - id: fire-ruby
+        name: Rubi de fogo
+        effect: 'Seus Ataques Mágicos ganham QUEIMADURA 2 e seus Ataques de Arma ganham “Sempre que você rolar 16+: Este ataque ganha QUEIMADURA 2.”'
+      - id: focused
+        name: Focado
+        effect: Sempre que qualquer Herói obtiver um Crítico, esse Herói ganha FOCO 1.
+      - id: folk-hero
+        name: Herói popular
+        effect: 'Sempre que você remover um Cubo de Maldição de seu painel, você também: EM SI, CURAR 2.'
+      - id: for-the-first-time
+        name: Pela primeira vez
+        effect: Depois que você gastar seu primeiro CA durante seu turno, você pode escolher recuperá-lo imediatamente (ele ainda conta como uma de suas Ações com Cubo). Este efeito ocorre antes de você tomar uma Ação de Recuperação Involuntária.
+      - id: foul-play
+        name: Jogo sujo
+        effect: Sempre que você tomar uma Ação de Recuperação, sofre VENENO 2.
+      - id: greetings
+        name: Saudações
+        effect: ''
+      - id: harmless
+        name: Inofensivo
+        effect: ''
+      - id: help-yourself
+        name: Sirva-se
+        effect: 'Como uma Ação Menor, você pode: EM SI, MALDIÇÃO 1 para retornar uma Pilha de Runas revelada inteira (que está no tabuleiro, não na Trilha de Iniciativa) para a sacola e ganhar FOCO 1.'
+      - id: horseblood
+        name: Sangue de cavalo
+        effect: Todos os Heróis são imunes a todas as Condições impostas por inimigos ou terreno prejudicial.
+      - id: inspired
+        name: Inspirado
+        effect: Uma vez por turno, você pode rerrolar um D20 quando errar.
+      - id: invincible
+        name: Invencível
+        effect: 'Como uma Ação Menor, você pode: EM SI, Remover um Cubo de Trauma para fazer com que o próximo Ataque de Arma (um único ataque, não a Ação com Cubo inteira) ou Ataque Mágico feito naquele turno cause dano dobrado.'
+      - id: key
+        name: Chave
+        effect: ''
+      - id: key-shard
+        name: Fragmento de chave
+        effect: ''
+      - id: master-of-undeath
+        name: Mestre da não-vida
+        effect: 'Sempre que você tomar uma Ação de Recuperação, após resolvê-la, você pode: EM SI, MALDIÇÃO 1. Se o fizer, ative uma Aparição de base pequena de sua escolha. Você controla seu turno durante essa ativação (você pode ignorar suas prioridades de mira e forçá-la a atacar outro Monstro).'
+      - id: meek
+        name: Manso
+        effect: Sempre que qualquer Herói fosse cair a 0 de PV ou menos, até um outro Herói pode fazer um Teste de Habilidade de Sabedoria (azul) de Dificuldade 15. Cada cubo de Sabedoria que ele tem lhe dá um bônus de +2 à sua rolagem. Se tiver sucesso, ele redireciona para si mesmo o dano que nocautearia aquele Herói (este dano não pode ser prevenido nem reagido).
+      - id: merciful
+        name: Misericordioso
+        effect: ''
+      - id: mistwalker
+        name: Caminhante da névoa
+        effect: 'Sempre que um Herói tomar uma Ação de Movimento, ele pode: EM SI, MALDIÇÃO 1. Se o fizer, ele remove seu Herói do tabuleiro e o coloca em qualquer casa revelada de sua escolha em vez de se mover. Isso é considerado “tomar uma Ação de Movimento” para fins de disparar habilidades.'
+      - id: noise
+        name: Ruído
+        effect: ''
+      - id: play-dumb
+        name: Fingir-se de tolo
+        effect: Você pode escolher não receber nenhum Cubo de Maldição ao tomar uma Ação de Recuperação.
+      - id: practical
+        name: Prático
+        effect: Sempre que qualquer Herói fosse receber um Ataque que fosse cair seu PV a 0 ou menos, como uma Reação esse Herói pode fazer um Teste de Habilidade de Agilidade (verde) de Dificuldade 15. Cada cubo de Agilidade que ele tem lhe dá um bônus de +2 à sua rolagem. Se tiver sucesso, ele SALTA 2 e PREVINE TODO o DANO que sofreria.
+      - id: protection-of-the-citadel
+        name: Proteção da Cidadela
+        effect: ''
+      - id: proud
+        name: Orgulhoso
+        effect: Sempre que qualquer Herói cair a 0 de PV ou menos, esse Herói pode fazer um Teste de Habilidade de Destreza (vermelho) de Dificuldade 15. Cada cubo À distância que ele tem lhe dá um bônus de +2 à sua rolagem. Se tiver sucesso, RETALIAR 10.
+      - id: reaping-a-hurricane
+        name: Colhendo um furacão
+        effect: 'No início de seu turno: EM SI, MALDIÇÃO 1. Em vez de colocar o CM que recebem em um Espaço de Habilidade, eles o mantêm como se fosse também um CA e ele pode ser usado naquele turno como um Cubo Curinga (ainda conta para o limite de CM que o Herói pode manter).'
+      - id: rest-in-peace
+        name: Descanse em paz
+        effect: ''
+      - id: restrained
+        name: Contido
+        effect: Todos os Heróis podem usar seus cubos verdes como se fossem cubos azuis ou amarelos. Sempre que um Herói usar um cubo verde para ativar uma Habilidade de Corpo a corpo que NÃO é um Ataque de Arma desta forma, essa Habilidade ganha Alcance ilimitado.
+      - id: safeguard
+        name: Salvaguarda
+        effect: 'Seus Ataques Mágicos ganham '', ESCUDO 2'' e seus Ataques de Arma ganham ''Sempre que você rolar 16+: ESCUDO 2.'''
+      - id: secret-passage
+        name: Passagem secreta
+        effect: ''
+      - id: shattered-barrier-inferno
+        name: 'Barreira despedaçada: Inferno'
+        effect: ''
+      - id: shattered-barrier-thunder
+        name: 'Barreira despedaçada: Trovão'
+        effect: ''
+      - id: steadfast
+        name: Firme
+        effect: Sempre que qualquer Herói cair a 0 de PV ou menos, esse Herói pode fazer um Teste de Habilidade de Força (amarelo) de Dificuldade 15. Cada cubo Corpo a corpo que ele tem lhe dá um bônus de +2 à sua rolagem. Se tiver sucesso, ele cai a 1 de PV em vez disso.
+      - id: tell-my-fingertips
+        name: Diga às pontas dos meus dedos
+        effect: ''
+      - id: the-honorable-gesture
+        name: O gesto honroso
+        effect: Sempre que você tomar uma Ação de Recuperação, também ganha FOCO 1.
+      - id: trick-or-treat
+        name: Doces ou travessuras
+        effect: 'Sempre que você tomar uma Ação de Recuperação, escolha uma: inflija QUEIMADURA 2 em um Alvo dentro do Alcance 1, ou, Alvo Herói dentro do Alcance 1, CURAR 2.'
+      - id: truthful
+        name: Verdadeiro
+        effect: Cada Herói pode manter dois Cubos de Maldição adicionais em seu painel.
+      - id: truth-seeker
+        name: Buscador da verdade
+        effect: 'Sempre que você remover um Cubo de Maldição de seu painel, você também: EM SI, ESCUDO 2.'
+      - id: unraveling-the-mystery
+        name: Desvendando o mistério
+        effect: Sempre que um efeito fosse invocar um Lacaio (Lacaios são um tipo específico de Monstro que não são Brancos, Cinzas ou Pretos), você pode Gastar 2 CA para cancelar o efeito de invocação. Você não pode cancelar Lacaios que são adicionados por uma Preparação, mas pode cancelar aqueles que são invocados por meio das habilidades de seus inimigos.
+      - id: warned
+        name: Alertado
+        effect: ''
+      - id: watch-your-step
+        name: Cuidado onde pisa
+        effect: ''
+      - id: waxed
+        name: Encerado
+        effect: ''
+    storyrecord: []
+  apocalypse:
+    campaign:
+      - id: a-strange-rod
+        name: Um Cetro Estranho
+        effect: ''
+      - id: bloodlust
+        name: Sede de Sangue
+        effect: Sempre que você derrotar um Monstro, você recebe INSPIRAR.
+      - id: bully
+        name: Valentão
+        effect: 'Sempre que você obtiver um Acerto Crítico: Você ganha um marcador de INSPIRAÇÃO.'
+      - id: chaotic-wheel
+        name: Roda Caótica
+        effect: 'Sempre que você conjurar um Ataque Mágico, role o D20: Se rolar um número par, ele causa DANO DOBRADO; Se rolar um número ímpar, o ataque falha.'
+      - id: crystal-clear
+        name: Cristalino
+        effect: Se você fosse comprar uma carta de Baú, procure no baralho por uma carta de sua escolha e pegue-a. Embaralhe o baralho de Baú depois.
+      - id: disappointed
+        name: Decepcionado
+        effect: Sempre que você rolar 1 no d20, obtém um Acerto Crítico e então pode RECICLAR.
+      - id: disgusted
+        name: Enojado
+        effect: Sempre que você Vasculhar um Baú, compre uma carta adicional, escolha uma dessas cartas para manter e coloque a outra no fundo do baralho de Baú.
+      - id: dismembered
+        name: Desmembrado
+        effect: Sempre que você tomar uma Ação de Recuperação, sofre ATORDOAR. Este ATORDOAR ignora qualquer tipo de imunidade que você tenha, já que representa sua dificuldade em lidar com suas ações após a recente perda de um membro.
+      - id: effort
+        name: Esforço
+        effect: ''
+      - id: empathetic
+        name: Empático
+        effect: Sempre que um Herói de seu grupo receber um Cubo de Maldição, ele pode pegá-lo em vez disso (pode escolher individualmente se receber mais de um em um único efeito).
+      - id: exquisite-attunement
+        name: Sintonia Refinada
+        effect: Sempre que você tomar a Ação de “Regra Especial de Desempate”, ganha tanto FOCO 1 quanto PURIFICAR 1 em vez de escolher um deles.
+      - id: guess-what
+        name: Adivinha
+        effect: No início de cada um de seus turnos, você pode reorganizar as Habilidades que estão sendo bloqueadas pelos Cubos de Maldição e Cubos de Trauma que está mantendo.
+      - id: heartbroken
+        name: De coração partido
+        effect: 'Sempre que você ou outro Herói de seu grupo sofrer dano: você ganha FÚRIA 1.'
+      - id: lash-out
+        name: Espernear
+        effect: Sempre que você rolar 1 no d20, você falha no atual teste de Precisão ou Teste de Habilidade que estiver fazendo e sofre FADIGA 4. Esta FADIGA ignora qualquer tipo de imunidade que seu Herói possa ter.
+      - id: orcish-perseverance
+        name: Perseverança Orc
+        effect: Você pode manter um Cubo de Trauma adicional.
+      - id: possession
+        name: Possessão
+        effect: Sempre que você se mover pelo terceiro espaço em um turno, deve fazer um Teste de Habilidade de Agilidade (verde) de Dificuldade 11. Cada cubo de Agilidade que você tem lhe dá um bônus de +2 à sua rolagem. Se falhar, você sofre DERRUBAR. Se tiver sucesso, você ganha FORTALECER em vez disso.
+      - id: queen-slayer
+        name: Matador de Rainha
+        effect: Sempre que você tomar uma Ação de Recuperação Voluntária ou Involuntária, o próximo Ataque de Arma ou Ataque Mágico que você fizer neste turno não requer um teste de Precisão e é considerado um Acerto Crítico.
+      - id: scornful
+        name: Desdenhoso
+        effect: Se você fosse sofrer apenas 1 ponto de dano de um Ataque, não sofre dano algum.
+      - id: second-thoughts
+        name: Segundos Pensamentos
+        effect: No início de seu turno, você pode recuperar um CA gasto em uma de suas Habilidades de Herói ou Função. Se o fizer, deve colocar um CA diferente em uma de suas Habilidades disponíveis; este efeito não ativa nenhuma de suas Habilidades.
+      - id: shielded-mind
+        name: Mente Protegida
+        effect: Você e cada Herói dentro do Alcance 1 de você são imunes a INTIMIDAR. Além disso, sempre que um Personagem tentar conjurar um efeito de INTIMIDAR contra você ou qualquer outro Herói dentro do Alcance 1 de você, o alvo desse efeito de INTIMIDAR recebe INSPIRAR em vez disso.
+      - id: veteran-s-sorrow
+        name: Tristeza do Veterano
+        effect: 'Sempre que você errar um Ataque de Arma, você pode: EM SI, MALDIÇÃO 1. Se o fizer, o ataque acerta em vez disso.'
+    storyrecord:
+      - id: a-broken-man
+        name: Um Homem Quebrado
+        effect: ''
+      - id: a-hard-bargain
+        name: Um Acordo Difícil
+        effect: ''
+      - id: afterlife-mysteries
+        name: Mistérios do Além
+        effect: Sempre que qualquer Herói obtiver um Acerto Crítico, ele pode Recuperar até um CA.
+      - id: aftermath
+        name: Rescaldo
+        effect: Sempre que um Herói de seu grupo tomar uma Ação de Recuperação, após resolvê-la, ele recebe PURIFICAR 1 ou FOCO 1.
+      - id: aggressive-negotiations
+        name: Negociações Agressivas
+        effect: ''
+      - id: anchor-locked
+        name: Âncora Presa
+        effect: ''
+      - id: anchor-sunk
+        name: Âncora Afundada
+        effect: ''
+      - id: anger-management
+        name: Controle de Raiva
+        effect: Sempre que um Herói sofrer dano de uma carta de Ataque, ele ganha INSPIRAR.
+      - id: angered-entrepreneur
+        name: Empresário Irado
+        effect: 'Sempre que um Herói rolar 16+: Ative Carmilla Reinard. Esta Habilidade só pode ser ativada uma vez por turno.'
+      - id: back-to-back
+        name: Costas com Costas
+        effect: Todos os Heróis de seu grupo ganham o traço GUARDIÃO.
+      - id: bad-hosting
+        name: Má Hospitalidade
+        effect: ''
+      - id: betrayed1
+        name: Traído (Condottieri)
+        effect: Sempre que um Herói derrotar um Condottieri, ele ganha FOCO 2 ou PURIFICAR 2.
+      - id: betrayed2
+        name: Traído (Dunedancer)
+        effect: Sempre que um Herói derrotar um Dunedancer, ele ganha FOCO 2 ou PURIFICAR 2.
+      - id: bloody-mess
+        name: Bagunça Sangrenta
+        effect: Sempre que um Herói cair a 0 de Vida, cada outro Herói sofre MALDIÇÃO 1.
+      - id: bricklayer-s-assistant
+        name: Ajudante do Pedreiro
+        effect: ''
+      - id: broken-man
+        name: Homem Quebrado
+        effect: ''
+      - id: clean-conscience
+        name: Consciência Limpa
+        effect: No início do turno de cada Herói, se ele não estiver mantendo nenhum Cubo de Maldição, ele recebe INSPIRAR.
+      - id: compassion
+        name: Compaixão
+        effect: Heróis não rolam o Dado de Armadilha ao abrir Baús.
+      - id: contempt
+        name: Desprezo
+        effect: Sempre que um Herói infligir dano ao Cavaleiro da Praga com um Ataque de Arma ou Ataque Mágico, ele ganha PURIFICAR 1.
+      - id: damsel-in-distress
+        name: Donzela em Perigo
+        effect: ''
+      - id: declawed-beast
+        name: Fera sem Garras
+        effect: ''
+      - id: deep-understanding
+        name: Compreensão Profunda
+        effect: Sempre que um Herói tomar uma Ação de Recuperação Voluntária, ele pode imediatamente tomar uma Ação com Cubo adicional antes de terminar seu turno.
+      - id: desert-knight
+        name: Cavaleiro do Deserto
+        effect: Sempre que um Herói derrotar um Condottieri, ele ganha FOCO 2 ou PURIFICAR 2.
+      - id: disarmed-father
+        name: Pai Desarmado
+        effect: ''
+      - id: downer
+        name: Estraga-prazeres
+        effect: Acertos Críticos não dobram mais o dano de um ataque.
+      - id: drowned-prayer
+        name: Prece Afogada
+        effect: ''
+      - id: element-collection
+        name: Coleção de Elementos
+        effect: ''
+      - id: even-number
+        name: Número Par
+        effect: ''
+      - id: frozen-to-death
+        name: Morto de Frio
+        effect: ''
+      - id: ghostly-plunder
+        name: Pilhagem Fantasmagórica
+        effect: 'Como uma Ação com Cubo, um Herói pode Gastar 1 CA para: Se houver três ou menos Baús no tabuleiro, colocar um Baú em uma casa adjacente a ele.'
+      - id: give-or-take
+        name: Dá ou Toma
+        effect: ''
+      - id: glyph-unraveled
+        name: Glifo Desvendado
+        effect: ''
+      - id: gold-digger
+        name: Garimpeiro
+        effect: Sempre que um Monstro for derrotado pela primeira vez em uma rodada, ele deixa cair um marcador de Saque.
+      - id: head-start
+        name: Vantagem Inicial
+        effect: 'Heróis podem tomar a seguinte Reação Gastando 1 CA: "EM SI, PREVENIR TODO o DANO E FADIGA Y onde Y é o número de marcadores de Tempo no Painel de Status de Monstro Chefe do Cavaleiro da Fome; Então o Cavaleiro da Fome recebe um marcador de Tempo (isso é apenas um lembrete, não uma Condição ou Recurso)."'
+      - id: healed-wound
+        name: Ferida Curada
+        effect: ''
+      - id: heirloom-blade
+        name: Lâmina de Herança
+        effect: ''
+      - id: herosplaining
+        name: Herói-explicando
+        effect: Sempre que um Herói rolar 1 no d20 ao atacar, ele obtém um Acerto Crítico em vez de uma Falha Crítica.
+      - id: improvisation-time
+        name: Hora de Improvisar
+        effect: Sempre que um Herói derrotar um Lacaio, ele ganha FOCO 1 ou PURIFICAR 1.
+      - id: initiative
+        name: Iniciativa
+        effect: 'Sempre que um Herói de seu grupo tomar uma Reação, role o D20: Se rolar 16+: Recupere o CA que acabou de gastar.'
+      - id: it-takes-two
+        name: São Precisos Dois
+        effect: O Coorte Robin Rising se ativa duas vezes durante cada um de seus turnos.
+      - id: lever-pushed
+        name: Alavanca Empurrada
+        effect: ''
+      - id: lifesaver
+        name: Salva-vidas
+        effect: ''
+      - id: luccanor-s-revenge
+        name: Vingança de Luccanor
+        effect: Sempre que um Herói infligir dano ao Comandante Traidor com um Ataque de Arma ou Ataque Mágico, ele ganha FOCO 1.
+      - id: no-maiden-fair
+        name: Nenhuma Donzela Bela
+        effect: ''
+      - id: obstinate
+        name: Obstinado
+        effect: Sempre que um Herói tomar uma Ação de Recuperação Voluntária, ele pode imediatamente tomar uma Ação com Cubo antes de terminar seu turno.
+      - id: odd-number
+        name: Número Ímpar
+        effect: ''
+      - id: past-life-hauntings
+        name: Assombrações de Vidas Passadas
+        effect: Se os Comandantes de Cenário Lorennor ou Uldannor receberem um efeito de CURAR, sofrerão a mesma quantidade de dano não prevenível em vez de recuperar Vida. Da mesma forma, se receberem PURIFICAR, sofrem INTIMIDAR 4 em vez de remover um Cubo de Maldição.
+      - id: perimeter-kept
+        name: Perímetro Mantido
+        effect: ''
+      - id: pirate-s-luck
+        name: Sorte de Pirata
+        effect: Sempre que o primeiro Monstro for derrotado em cada nova Preparação que seu grupo fizer, substitua sua miniatura por um marcador de Saque. Se esse Monstro for um Monstro Grande, Comandante ou Suserano, substitua-o por dois desses marcadores.
+      - id: post-traumatic-stress
+        name: Estresse Pós-Traumático
+        effect: Sempre que um Herói for Nocauteado, cada outro Herói de seu grupo ganha FOCO 1 e sofre MALDIÇÃO 1. Este efeito ignora qualquer tipo de imunidade que um Herói possa ter.
+      - id: questioning
+        name: Questionamento
+        effect: ''
+      - id: removed-helmet
+        name: Elmo Removido
+        effect: ''
+      - id: removed-necklace
+        name: Colar Removido
+        effect: ''
+      - id: removed-shield
+        name: Escudo Removido
+        effect: ''
+      - id: righteous
+        name: Justo
+        effect: Heróis de seu grupo podem manter um Cubo de Trauma adicional.
+      - id: royal-outrage
+        name: Ultraje Real
+        effect: ''
+      - id: sealed-fate
+        name: Destino Selado
+        effect: ''
+      - id: ship-s-on
+        name: O Navio Segue
+        effect: ''
+      - id: suspicious
+        name: Suspeito
+        effect: Heróis que estão sendo ameaçados podem tomar uma Reação adicional contra suas ameaças.
+      - id: swallowed-pride
+        name: Orgulho Engolido
+        effect: Sempre que um Herói obtiver um Crítico, esse Herói também ganha FOCO 2.
+      - id: terrible-fate
+        name: Destino Terrível
+        effect: ''
+      - id: the-heirloom-blade
+        name: A Lâmina de Herança
+        effect: ''
+      - id: thy-kingdom-come
+        name: Venha o Teu Reino
+        effect: ''
+      - id: two-words
+        name: Duas Palavras
+        effect: ''
+      - id: umbralian-knight
+        name: Cavaleiro Umbraliano
+        effect: Sempre que um Herói derrotar um Dunedancer, ele ganha FOCO 2 ou PURIFICAR 2.
+      - id: until-the-end
+        name: Até o Fim
+        effect: Sempre que um Herói tomar a ação da Mecânica Especial de Desempate, a Cavaleira da Guerra perde 2 de Vida por Runa removida.
+      - id: varatash-terror
+        name: Terror de Varatash
+        effect: 'No início do turno de cada Herói, ele ganha: EM SI, INSPIRAR.'
+      - id: weak-spot
+        name: Ponto Fraco
+        effect: Sempre que qualquer Herói acertar o Cavaleiro da Fome com um Ataque de Arma ou um Acerto Crítico, ele escolhe uma de suas cartas de Ataque para receber INTIMIDAR 2 (até um máximo de 4 por carta). Na próxima vez que essa carta for ativada, remova todos esses marcadores dela. O Ataque ativado causa -1 de dano por marcador removido desta forma.
+      - id: well-fed
+        name: Bem Alimentado
+        effect: Heróis recebem apenas dois Cubos de Maldição como penalidade ao tomar uma Ação de Recuperação.
+  awakenings:
+    campaign:
+      - id: acquaintance
+        name: Conhecido
+        effect: ''
+      - id: better-judgment
+        name: Bom Senso
+        effect: Uma vez por turno, depois de errar com um Ataque de Arma feito de uma Habilidade, você pode Recuperar o cubo que acabou de gastar para usar essa Habilidade.
+      - id: corrupt-power
+        name: Poder Corrompido
+        effect: Heróis nunca podem ter menos de 2 Cubos de Maldição em seus painéis e, uma vez por turno, podem rolar o d20 se não gostaram do resultado de um movimento.
+      - id: haunted
+        name: Assombrado
+        effect: Sempre que você rolar 1 no d20 ao atacar, se um Aliado estiver no Alcance do ataque, ele é atingido em vez de um Monstro (isso acontece mesmo que você tenha habilidades que transformam rolagens de 1 em acertos ou acertos críticos).
+      - id: lifesaver
+        name: Salva-vidas
+        effect: Como uma Ação com Cubo, você pode Gastar 1 Cubo de Ação para pegar 2 Cubos de Maldição (pegar um Cubo de Maldição é diferente de sofrer MALDIÇÃO) e remover um Cubo de Trauma de um Herói Nocauteado que esteja adjacente a você. Se esse Herói já tiver Recuperado o Fôlego, você não pode remover seu Cubo de Trauma desta forma.
+      - id: power-of-hate
+        name: Poder do Ódio
+        effect: Heróis podem tomar 1 Ação com Cubo adicional em seus turnos.
+      - id: shadow-crown
+        name: Coroa das Sombras
+        effect: Heróis não são afetados pela Escuridão (não sofrem nem o dano nem as penalidades).
+      - id: soft-heart
+        name: Coração Mole
+        effect: Enquanto houver outro Herói adjacente a você, esse Herói receberá os benefícios da Aura "Sombrio" (os benefícios da Aura só se aplicam enquanto você ainda estiver adjacente a ele).
+      - id: sweet-scent
+        name: Aroma Doce
+        effect: Lacaios são enfeitiçados por seu cheiro agradável e são incapazes de atacar você (não consideram você como um alvo) e o Javali Selvagem que perambula pela ilha (se ainda estiver vivo) não tentará mais escapar. Em vez disso, ele se moverá em sua direção, tentando permanecer adjacente a você.
+    storyrecord:
+      - id: acquaintance
+        name: Conhecido
+        effect: ''
+      - id: acquainted
+        name: Familiarizado
+        effect: ''
+      - id: bright-pupil
+        name: Aluno Brilhante
+        effect: ''
+      - id: careful
+        name: Cuidadoso
+        effect: ''
+      - id: christi-s-aid
+        name: Ajuda de Christi
+        effect: Sempre que um Herói de seu grupo tomar uma Ação de Recuperação, esse Herói ganha um marcador de Inspiração
+      - id: dark-past
+        name: Passado Obscuro
+        effect: ''
+      - id: guided
+        name: Guiado
+        effect: ''
+      - id: heirloom
+        name: Herança
+        effect: ''
+      - id: imminent-danger
+        name: Perigo Iminente
+        effect: ''
+      - id: karsten-freed
+        name: Karsten Libertado
+        effect: ''
+      - id: king-s-cause
+        name: Causa do Rei
+        effect: ''
+      - id: loose-arm
+        name: Braço Solto
+        effect: ''
+      - id: nautical-empathy
+        name: Empatia Náutica
+        effect: ''
+      - id: painful-memories
+        name: Memórias Dolorosas
+        effect: ''
+      - id: pirate-s-gift
+        name: Presente do Pirata
+        effect: ''
+      - id: pushover
+        name: Frouxo
+        effect: ''
+      - id: remorse
+        name: Remorso
+        effect: ''
+      - id: salamander-s-sweat
+        name: Suor de Salamandra
+        effect: 'Sempre que um Herói rolar 16+ durante um ataque com Ataque de Arma ou conjurar um Ataque Mágico: o ataque ganha QUEIMADURA 2.'
+      - id: sea-fighter
+        name: Guerreiro do Mar
+        effect: No fim do turno da Runa, após os efeitos da carta de Runa serem resolvidos, cada Herói pode tomar um DESVIO LATERAL. Um DESVIO LATERAL é um efeito de MOVER 1 que não é afetado por nenhum bônus ou penalidade de movimento que você possa ter. Além disso, pode ser tomado mesmo se você estiver LENTO ou DERRUBADO, porém, essas Condições não são removidas.
+      - id: search-party
+        name: Grupo de Busca
+        effect: Sempre que um Herói de seu grupo comprar uma carta de Evento Especial das Surpresas de Eradren, esse Herói ganha FOCO 2
+      - id: sunken-relic
+        name: Relíquia Afundada
+        effect: ''
+      - id: suspicious
+        name: Suspeito
+        effect: Sempre que um Herói Vasculhar um Baú, compra uma carta adicional, escolhe uma dessas cartas para manter e coloca a outra no fundo do baralho de Baú.
+      - id: the-x-mark-the-spot
+        name: O X Marca o Local
+        effect: Sempre que um Herói desferir o golpe mortal por meio de um Acerto Crítico, o Monstro derrotado deixa cair um marcador de Saque em sua casa.
+      - id: turn-around
+        name: Reviravolta
+        effect: 'Qualquer bônus de ACERTO em Ataque de Arma que seus Ataques teriam ou receberiam se torna bônus de DANO em vez disso. Exemplo: O Balanço em Arco de Vorn diz: “TALHAR 2, +3 ACERTO”; portanto, se torna: “TALHAR 2, +0 ACERTO, +3 DANO”. Qualquer bônus de ACERTO que seu Herói tenha por Equipamento, Habilidades de Classe ou Efeitos Especiais também se transforma em dano bônus.'
+      - id: wrong-foot
+        name: Pé Errado
+        effect: ''
+unfolding:
+  core:
+    campaign: []
+    storyrecord: []
+  apocalypse:
+    campaign: []
+    storyrecord:
+      - id: a-broken-man
+        name: Um Homem Quebrado
+        act: 2
+      - id: a-crown-with-no-jewels
+        name: Uma Coroa sem Joias
+        act: 2
+      - id: a-hero-restored
+        name: Um Herói Restaurado
+        act: 2
+      - id: carmillas-goodbye
+        name: Adeus de Carmilla
+        act: 1
+      - id: compromising
+        name: Comprometendo
+        act: 4
+      - id: connecting-dots
+        name: Ligando os Pontos
+        act: 3
+      - id: crossroads
+        name: Encruzilhada
+        act: 3
+      - id: gil-garoth-reborn
+        name: Gil Garoth Renascido
+        act: 2
+      - id: heroic-folks
+        name: Gente Heroica
+        act: 1
+      - id: luccanors-redemption
+        name: Redenção de Luccanor
+        act: 1
+      - id: luccanors-regret
+        name: Arrependimento de Luccanor
+        act: 1
+      - id: no-ones-land
+        name: Terra de Ninguém
+        act: 2
+      - id: survivors-survived
+        name: Sobreviventes Sobrevivem
+        act: 3
+      - id: the-bargain
+        name: O Acordo
+        act: 3
+      - id: the-bonds-uniting-us
+        name: Os Laços que Nos Unem
+        act: 3
+      - id: the-desert-flower
+        name: A Flor do Deserto
+        act: 2
+      - id: the-earl-of-nothing
+        name: O Conde do Nada
+        act: 3
+      - id: the-fallout
+        name: As Consequências
+        act: 4
+      - id: the-good-duke
+        name: O Bom Duque
+        act: 1
+      - id: the-last-dance
+        name: A Última Dança
+        act: 2
+      - id: the-safeguard-corporation
+        name: A Corporação Salvaguarda
+        act: 3
+      - id: to-be-or-not-to-be
+        name: Ser ou Não Ser?
+        act: 1
+      - id: tragic-fate
+        name: Destino Trágico
+        act: 3
+      - id: truth-untold
+        name: Verdade Não Contada
+        act: 1
+      - id: what-goes-around-comes-around
+        name: Tudo o que Vai, Volta
+        act: 3
+  awakenings:
+    campaign: []
+    storyrecord: []
+followers:
+  core:
+    campaign: []
+    storyrecord: []
+  apocalypse:
+    campaign: []
+    storyrecord:
+      - id: amster-dehanse
+        name: Amsterd deHanse
+      - id: carmilla-reinard
+        name: Carmilla Reinard
+      - id: condottieri-daviggo
+        name: Condottieri DaViggo
+      - id: dunedancer-khadija
+        name: Dunedancer Khadija
+      - id: robin-rising
+        name: Robin Rising
+  awakenings:
+    campaign: []
+    storyrecord:
+      - id: elros
+        name: Elros, o Assassino
+      - id: lorelai
+        name: Lorelai, a Maga
+      - id: maya
+        name: Maya, a Patrulheira
+      - id: minerva
+        name: Minerva
+      - id: vorn
+        name: Vorn, o Guerreiro

--- a/src/locales/pt_BR/items.yaml
+++ b/src/locales/pt_BR/items.yaml
@@ -1,1 +1,468 @@
----
+weapon:
+  underkeep2:
+    tools-of-the-trade: Ferramentas do Ofício
+    amiran-hammer: Martelo Amiran
+    magicians-staff: Cajado do Mago
+    robins-crossbow: Besta de Robin
+    dwarven-warhammer: Martelo de Guerra Anão
+    weapon-of-the-ancients: Arma dos Anciões
+  underkeep:
+    tools-of-the-trade: Ferramentas do Ofício
+    amiran-hammer: Martelo Amiran
+    magicians-staff: Cajado do Mago
+    robins-crossbow: Besta de Robin
+    dwarven-warhammer: Martelo de Guerra Anão
+    masterwork-sword: Espada de Mestre
+    lumberjacks-axe: Machado do Lenhador
+    elanian-crossbow: Besta Elaniana
+    elven-speellblade: Lâmina Mágica Élfica
+    stone-gladius: Gládio de Pedra
+    lost-claymore: Claymore Perdida
+    lost-claymore-gem: Claymore Perdida (Gema Cósmica)
+    draconian-scimitar: Cimitarra Dracônica
+    draconian-scimitar-gem: Cimitarra Dracônica (Gema Cósmica)
+    lorelanian-longbow: Arco Longo Lorelaniano
+    lorelanian-longbow-gem: Arco Longo Lorelaniano (Gema Cósmica)
+    redwood-staff: Cajado de Sequoia
+    redwood-staff-gem: Cajado de Sequoia (Gema Cósmica)
+  core:
+    amiran-crossbow: Besta Amiran
+    amiran-halberd: Alabarda Amiran
+    amiran-royal-maul: Malho Real Amiran
+    battle-maul: Malho de Batalha
+    blacksteel-blade: Lâmina de Aço Negro
+    blacksteel-greatsword: Espada Grande de Aço Negro
+    blacksteel-longsword: Espada Longa de Aço Negro
+    blooded-sword: Espada Sangrenta
+    bloody-axe-cosmic-gem: Machado Sangrento (Gema Cósmica)
+    bloody-axe-socketed: Machado Sangrento (Encaixado)
+    corruptor-knife: Faca Corruptora
+    crossbow: Besta
+    dreampiercer-bow: Arco Perfura-Sonhos
+    dwarven-kings-sword-cosmic-gem: Espada do Rei Anão (Gema Cósmica)
+    dwarven-kings-sword-socketed: Espada do Rei Anão (Encaixada)
+    elvish-bow: Arco Élfico
+    enchanted-crossbow-cosmic-gem: Besta Encantada (Gema Cósmica)
+    enchanted-crossbow-socketed: Besta Encantada (Encaixada)
+    exquisite-dreamblade: Lâmina Onírica Refinada
+    hellscarian-short-bow: Arco Curto de Hellscar
+    jagged-blade-axe: Machado de Lâmina Serrilhada
+    light-maul: Malho Leve
+    marksman-bow: Arco de Atirador
+    orcish-blade: Lâmina Orc
+    orcish-cleaver: Cutelo Orc
+    orcish-reaper-blade: Lâmina Ceifadora Orc
+    repeating-crossbow: Besta de Repetição
+    runecarved-blade: Lâmina Rúnica
+    staff-of-the-arcana: Cajado dos Arcanos
+    staff-of-the-dawn: Cajado da Aurora
+    staff-of-the-moon: Cajado da Lua
+    staff-of-the-noon: Cajado do Meio-Dia
+    staff-of-the-stars: Cajado das Estrelas
+    staff-of-the-twilight: Cajado do Crepúsculo
+    staff-of-the-wildfire-cosmic-gem: Cajado do Fogo Selvagem (Gema Cósmica)
+    staff-of-the-wildfire-socketed: Cajado do Fogo Selvagem (Encaixado)
+    sword-of-the-dynasty: Espada da Dinastia
+    sword-of-the-prince: Espada do Príncipe
+    terror-blade: Lâmina do Terror
+    valaranian-runebow: Arco Rúnico Valaraniano
+    vicious-knife: Faca Cruel
+    wooden-staff: Cajado de Madeira
+  undeaddragon:
+    dark-piercer: Perfurador Sombrio
+    bane-of-the-shadows: Ruína das Sombras
+  desertofhellscar:
+    staff-of-gravity: Cajado da Gravidade
+    weapon-of-the-ancients: Arma dos Anciões
+  apocalypse:
+    axe-of-the-steppes: Machado das Estepes
+    counselors-staff: Cajado do Conselheiro
+    empyrean-bowstaff: Arco-Cajado Empíreo
+    gil-garoths-sword: Espada de Gil Garoth
+    hellscarian-falchion: Falchion de Hellscar
+    hunting-shotbow: Arco Curto de Caça
+    improved-arbalast: Arbalete Aprimorado
+    improved-arcannon: Arcanhão Aprimorado
+    improved-claymore: Claymore Aprimorada
+    improved-crossbow: Besta Aprimorada
+    improved-longsword: Espada Longa Aprimorada
+    improved-rapier: Rapieira Aprimorada
+    improved-royal-staff: Cajado Real Aprimorado
+    lionhearteds-sword: Espada Coração-de-Leão
+    standard-arbalast: Arbalete Padrão
+    standard-arcannon: Arcanhão Padrão
+    standard-claymore: Claymore Padrão
+    standard-crossbow: Besta Padrão
+    standard-longsword: Espada Longa Padrão
+    standard-rapier: Rapieira Padrão
+    standard-royal-staff: Cajado Real Padrão
+    sword-of-kane: Espada de Kane
+    ultimate-arbalast: Arbalete Definitivo
+    ultimate-arcannon: Arcanhão Definitivo
+    ultimate-claymore: Claymore Definitiva
+    ultimate-crossbow: Besta Definitiva
+    ultimate-longsword: Espada Longa Definitiva
+    ultimate-rapier: Rapieira Definitiva
+    ultimate-royal-staff: Cajado Real Definitivo
+  awakenings:
+    arcabalest: Arcabalesta
+    chaos-staff: Cajado do Caos
+    cleavescythe: Cortafoice
+    hack-slash: Corte-Retalho
+    improved-hack-slash: Corte-Retalho Aprimorado
+    improved-twin-blades: Lâminas Gêmeas Aprimoradas
+    improved-cleavescythe: Cortafoice Aprimorada
+    improved-chaos-staff: Cajado do Caos Aprimorado
+    improved-war-bow: Arco de Guerra Aprimorado
+    improved-arcabalest: Arcabalesta Aprimorada
+    twin-blades: Lâminas Gêmeas
+    rancor-blade: Lâmina do Rancor
+    ultimate-hack-slash: Corte-Retalho Definitivo
+    ultimate-twin-blades: Lâminas Gêmeas Definitivas
+    ultimate-cleavescythe: Cortafoice Definitiva
+    ultimate-chaos-staff: Cajado do Caos Definitivo
+    ultimate-war-bow: Arco de Guerra Definitivo
+    ultimate-arcabalest: Arcabalesta Definitiva
+    war-bow: Arco de Guerra
+trinket:
+  underkeep2:
+    callix-fire-beer: Cerveja de Fogo Callix
+    zullan-rush-beer: Cerveja Ímpeto Zullan
+    cormack-house-crest: Brasão da Casa Cormack
+    quicksilver-ring: Anel de Mercúrio
+  underkeep:
+    locket-of-safeguard: Medalhão da Salvaguarda
+    silver-helmet: Elmo de Prata
+    living-torch: Tocha Viva
+    gravity-boots: Botas da Gravidade
+    gravity-boots-gem: Botas da Gravidade (Gema Cósmica)
+    ring-of-mastery: Anel da Maestria (Presente)
+    bracers-of-endurance: Braceletes da Resistência (Presente)
+    bauble-of-power: Berloque do Poder (Presente)
+    boots-of-haste: Botas da Pressa (Presente)
+    heroic-heart: Coração Heroico (Presente)
+  core:
+    amulet-of-power: Amuleto do Poder
+    amulet-of-rewinding: Amuleto do Retrocesso
+    amulet-of-the-copycat: Amuleto do Imitador
+    badge-of-the-wardens: Insígnia dos Guardiões
+    blue-flame-torch: Tocha de Chama Azul
+    boots-of-agility: Botas da Agilidade
+    boots-of-levitation: Botas da Levitação
+    boots-of-striding: Botas do Passo Longo
+    bracers-of-endurance: Braceletes da Resistência
+    broken-phylactery: Filactério Quebrado
+    cursed-bracelet: Bracelete Amaldiçoado
+    dewey-and-guss-collar: Coleira de Dewey & Guss
+    family-locket-cosmic-gem: Medalhão de Família (Gema Cósmica)
+    family-locket-socketed: Medalhão de Família (Encaixado)
+    gold-medal: Medalha de Ouro
+    golden-locket: Medalhão Dourado
+    good-quality-stick: Bastão de Boa Qualidade
+    good-quality-torch: Tocha de Boa Qualidade
+    lovers-promise: Promessa de Amantes
+    periapt-of-greater-healing: Amuleto de Cura Maior
+    periapt-of-healing: Amuleto de Cura
+    periapt-of-supreme-healing: Amuleto de Cura Suprema
+    ring-of-greater-precision: Anel da Precisão Maior
+    ring-of-legendary-precision: Anel da Precisão Lendária
+    ring-of-precision: Anel da Precisão
+    ruby-brooch: Broche de Rubi
+    seed-of-darkness-bright: Semente das Trevas (Brilhante)
+    seed-of-darkness-dim: Semente das Trevas (Opaca)
+    sigil-of-narangerel: Sigilo de Narang'erel
+    teddy-bear: Ursinho de Pelúcia
+    bond-of-superation: Elo da Superação
+    badge-of-the-west-wind: Insígnia do Vento Oeste
+  undeaddragon:
+    dragon-eye-of-memory: Olho de Dragão da Memória
+  desertofhellscar:
+    frozen-tears-of-alagast: Lágrimas Congeladas de Alagast
+  apocalypse:
+    chain-of-the-lost-world: Corrente do Mundo Perdido
+    eldritch-symbiot: Simbionte Eldritch
+    executioners-helmet: Elmo do Executor
+    gilded-collar-death: Coleira Dourada (Morte)
+    gilded-collar-life: Coleira Dourada (Vida)
+    grayrock-signet: Sinete de Cinzarocha
+    improved-eldritch-mask: Máscara Eldritch Aprimorada
+    improved-emerald-ring: Anel de Esmeralda Aprimorado
+    improved-power-gauntlet: Manopla do Poder Aprimorada
+    improved-titan-stompers: Pisadores Titânicos Aprimorados
+    jeweled-necklace: Colar Enjoiado
+    outlander-helmet: Elmo do Forasteiro
+    ragged-doll: Boneca Esfarrapada
+    rainbow-mask: Máscara Arco-Íris
+    righteous-torch: Tocha Justiceira
+    sapphire-pendant: Pingente de Safira
+    sprout-of-darkness: Broto das Trevas
+    standard-eldritch-mask: Máscara Eldritch Padrão
+    standard-emerald-ring: Anel de Esmeralda Padrão
+    standard-power-gauntlet: Manopla do Poder Padrão
+    standard-titan-stompers: Pisadores Titânicos Padrão
+    ultimate-eldritch-mask: Máscara Eldritch Definitiva
+    ultimate-emerald-ring: Anel de Esmeralda Definitivo
+    ultimate-power-gauntlet: Manopla do Poder Definitiva
+    ultimate-titan-stompers: Pisadores Titânicos Definitivos
+    vow-keeper: Guardião do Voto
+  awakenings:
+    accuracy-ring: Anel da Precisão
+    cornucopia: Cornucópia
+    arcane-glove: Luva Arcana
+    black-harpoon: Arpão Negro
+    bright-crest: Brasão Brilhante
+    captains-brooch: Broche do Capitão
+    christis-kitten: Gatinho de Christi
+    cosmic-heart-chipped: Coração Cósmico - Trincado
+    cosmic-heart-flawless: Coração Cósmico - Impecável
+    eradrens-lamp: Lâmpada de Eradren
+    felix-felis: Felix Felis
+    fighters-ring-back: Anel do Lutador (Costas)
+    fighters-ring-front: Anel do Lutador (Frente)
+    grimoire: Grimório
+    huntmasters-whistle: Apito do Mestre-Caçador
+    improved-accuracy-ring: Anel da Precisão Aprimorado
+    improved-tracker-boots: Botas do Rastreador Aprimoradas
+    improved-cornucopia: Cornucópia Aprimorada
+    improved-grimoire: Grimório Aprimorado
+    loriens-flute: Flauta de Lorien
+    mind-gem: Gema da Mente
+    polished-helmet: Elmo Polido
+    token-of-friendship: Símbolo da Amizade
+    tracker-boots: Botas do Rastreador
+    trappers-toolkit: Kit do Trapaceiro
+    ultimate-accuracy-ring: Anel da Precisão Definitivo
+    ultimate-tracker-boots: Botas do Rastreador Definitivas
+    ultimate-cornucopia: Cornucópia Definitiva
+    ultimate-grimoire: Grimório Definitivo
+armor:
+  underkeep2:
+    smugglers-vest: Colete do Contrabandista
+    clerics-mail: Cota do Clérigo
+    elvensilk-robe: Túnica de Seda Élfica
+    hunters-cuirass: Couraça do Caçador
+    dwarven-plate: Armadura de Placas Anã
+    noon-plate: Armadura de Placas do Meio-Dia
+    twilight-leather: Couro do Crepúsculo
+    night-plate: Armadura de Placas da Noite
+  underkeep:
+    smugglers-vest: Colete do Contrabandista
+    clerics-mail: Cota do Clérigo
+    elvensilk-robe: Túnica de Seda Élfica
+    hunters-cuirass: Couraça do Caçador
+    dwarven-plate: Armadura de Placas Anã
+    mirror-plate: Armadura de Placas Espelhada
+    astralsilk-robe: Túnica de Seda Astral
+    astralsilk-robe-gem: Túnica de Seda Astral (Gema Cósmica)
+    dragonhide-cuirass: Couraça de Pele de Dragão
+    dragonhide-cuirass-gem: Couraça de Pele de Dragão (Gema Cósmica)
+    quicksilver-breastplate: Peitoral de Mercúrio
+    quicksilver-breastplate-gem: Peitoral de Mercúrio (Gema Cósmica)
+  core:
+    breastplate: Peitoral
+    cloth-armor: Armadura de Tecido
+    displacement-cloak: Manto do Deslocamento
+    dream-weaveplate: Armadura Tecida em Sonhos
+    full-plate-armor: Armadura Completa de Placas
+    greater-displacement-cloak: Manto do Deslocamento Maior
+    greater-spellweave-cloak: Manto Tecido por Magia Maior
+    half-plate-armor: Meia-Armadura de Placas
+    heavy-thornmail: Cota de Espinhos Pesada
+    leather-armor: Armadura de Couro
+    lesser-displacement-cloak: Manto do Deslocamento Menor
+    lesser-spellweave-cloak: Manto Tecido por Magia Menor
+    light-thornmail: Cota de Espinhos Leve
+    padded-leather-armor: Armadura de Couro Acolchoada
+    plate-armor: Armadura de Placas
+    reinforced-leather-armor: Armadura de Couro Reforçada
+    reinforced-shadow-leather: Couro Sombrio Reforçado
+    runecarved-cloak: Manto Rúnico
+    shadow-leather-armor: Armadura de Couro Sombrio
+    spellweave-cloak: Manto Tecido por Magia
+    studded-leather-armor: Armadura de Couro Cravejada
+    studded-shadow-leather: Couro Sombrio Cravejado
+    thornmail: Cota de Espinhos
+    xerethian-breastplate: Peitoral Xerethiano
+  desertofhellscar:
+    wormscale-breastplate: Peitoral de Escamas de Verme
+  apocalypse:
+    condottieris-breastplate: Peitoral do Condottieri
+    improved-arming-doublet: Gibão de Armar Aprimorado
+    improved-cape-of-the-magi: Capa dos Magi Aprimorada
+    improved-lorica-armor: Armadura Lorica Aprimorada
+    improved-royal-plate: Armadura Real Aprimorada
+    improved-shadow-leather: Couro Sombrio Aprimorado
+    masterpiece-armor: Armadura Obra-Prima
+    outlander-black-plate: Armadura Negra do Forasteiro
+    scholars-robe: Túnica do Erudito
+    standard-arming-doublet: Gibão de Armar Padrão
+    standard-cape-of-the-magi: Capa dos Magi Padrão
+    standard-lorica-armor: Armadura Lorica Padrão
+    standard-royal-plate: Armadura Real Padrão
+    standard-shadow-leather: Couro Sombrio Padrão
+    ultimate-arming-doublet: Gibão de Armar Definitivo
+    ultimate-cape-of-the-magi: Capa dos Magi Definitiva
+    ultimate-lorica-armor: Armadura Lorica Definitiva
+    ultimate-royal-plate: Armadura Real Definitiva
+    ultimate-shadow-leather: Couro Sombrio Definitivo
+    veteran-cuirass: Couraça de Veterano
+    warworn-breastplate: Peitoral Marcado pela Guerra
+  awakenings:
+    battle-plate: Armadura de Batalha
+    exquisite-mail: Cota Refinada
+    improved-mystics-robe: Túnica do Místico Aprimorada
+    improved-rogues-vest: Colete do Ladino Aprimorado
+    improved-battle-plate: Armadura de Batalha Aprimorada
+    improved-exquisite-mail: Cota Refinada Aprimorada
+    improved-quilted-doublet: Gibão Acolchoado Aprimorado
+    mystics-robe: Túnica do Místico
+    quilted-doublet: Gibão Acolchoado
+    rogues-vest: Colete do Ladino
+    ultimate-mystics-robe: Túnica do Místico Definitiva
+    ultimate-rogues-vest: Colete do Ladino Definitivo
+    ultimate-battle-plate: Armadura de Batalha Definitiva
+    ultimate-exquisite-mail: Cota Refinada Definitiva
+    ultimate-quilted-doublet: Gibão Acolchoado Definitivo
+consumable:
+  underkeep2:
+    scroll-of-incinerate: Pergaminho da Incineração
+    potion-of-rejuvenation: Poção do Rejuvenescimento
+    scroll-of-winter: Pergaminho do Inverno
+    potion-of-strength: Poção da Força
+    scroll-of-sudden-death: Pergaminho da Morte Súbita
+    potion-of-concentration: Poção da Concentração
+    explosive-brew: Beberagem Explosiva
+    winter-brew: Beberagem do Inverno
+    dragon-gem: Gema do Dragão
+  underkeep:
+    cosmic-ruby: Rubi Cósmico
+    scroll-of-incinerate: Pergaminho da Incineração
+    potion-of-rejuvenation: Poção do Rejuvenescimento
+    scroll-of-winter: Pergaminho do Inverno
+    potion-of-strength: Poção da Força
+    potion-of-concentration: Poção da Concentração
+    scroll-of-sudden-death: Pergaminho da Morte Súbita
+  core:
+    cosmic-gemstone: Gema Cósmica
+    cosmic-gemstone-chest: Gema Cósmica (Baú)
+    cosmic-gemstone-from-sigil-of-honor: Gema Cósmica (Do Sigilo da Honra)
+    dreamcrafted-pattern-bracers-of-endurance: Padrão Onírico (Braceletes da Resistência)
+    dreamcrafted-pattern-dream-weaveplate: Padrão Onírico (Armadura Tecida em Sonhos)
+    dreamcrafted-pattern-dreamcrafted-buckler: Padrão Onírico (Broquel Onírico)
+    dreamcrafted-pattern-dreampiercer-bow: Padrão Onírico (Arco Perfura-Sonhos)
+    dreamcrafted-pattern-exquisite-dreamblade: Padrão Onírico (Lâmina Onírica Refinada)
+    dreamcrafted-pattern-sigil-of-narangerel: Padrão Onírico (Sigilo de Narang'erel)
+    potion-of-fortitude: Poção da Fortitude
+    potion-of-healing: Poção de Cura
+    potion-of-preparation: Poção da Preparação
+    scroll-of-displacement: Pergaminho do Deslocamento
+    scroll-of-icy-bolts: Pergaminho de Raios Gelados
+    scroll-of-incinerate: Pergaminho da Incineração
+    scroll-of-unmaking: Pergaminho da Desfazedura
+  apocalypse:
+    artisans-tools: Ferramentas do Artesão (Veterano)
+    scroll-of-charm: Pergaminho do Encantamento
+    scroll-of-the-copy-cat: Pergaminho do Imitador
+    scroll-of-translocation: Pergaminho da Translocação
+    treasure-trove: Baú do Tesouro (Veterano)
+  awakenings:
+    artisans-tools: Ferramentas do Artesão (Herói)
+    combustible-grenade: Granada Combustível
+    dragons-breath: Sopro do Dragão
+    potion-of-haste: Poção da Pressa
+    potion-of-strength: Poção da Força
+    scroll-of-beguile: Pergaminho da Sedução
+    scroll-of-polymorph: Pergaminho do Polimorfismo
+    scroll-of-protection: Pergaminho da Proteção
+    treasure-trove: Baú do Tesouro (Herói)
+offhand:
+  underkeep:
+    ebony-chair: Cadeira de Ébano
+    masterwork-sword: Espada de Mestre
+    earls-shield: Escudo do Conde
+    arcane-bulwark: Baluarte Arcano
+    ritual-dagger: Adaga Ritual
+    bulwark-shield: Escudo Baluarte (Presente)
+    hallowed-symbol: Símbolo Sagrado (Presente)
+    weakening-dagger: Adaga Enfraquecedora (Presente)
+  core:
+    deadly-backstabber: Apunhalador Mortífero
+    deft-stilleto: Estilete Ágil
+    dreamcrafted-buckler: Broquel Onírico
+    dueling-dagger: Adaga de Duelo
+    empowered-pact-blade: Lâmina do Pacto Fortalecida
+    greater-mystical-symbol: Símbolo Místico Maior
+    greater-symbol-of-light: Símbolo da Luz Maior
+    heavy-shield: Escudo Pesado
+    iron-shield: Escudo de Ferro
+    kite-shield-cosmic-gem: Escudo Papagaio (Gema Cósmica)
+    kite-shield-socketed: Escudo Papagaio (Encaixado)
+    lesser-mystical-symbol: Símbolo Místico Menor
+    lesser-symbol-of-light: Símbolo da Luz Menor
+    mystical-symbol: Símbolo Místico
+    pact-blade: Lâmina do Pacto
+    round-brass-shield: Escudo Redondo de Latão
+    round-golden-shield: Escudo Redondo Dourado
+    round-silver-shield: Escudo Redondo de Prata
+    runecarved-shield: Escudo Rúnico
+    sigil-of-honor: Sigilo da Honra
+    steel-shield: Escudo de Aço
+    symbol-of-light: Símbolo da Luz
+    throwing-dagger: Adaga de Arremesso
+    undermountain-scabbard: Bainha das Profundezas
+    vengeful-pact-blade: Lâmina do Pacto Vingativa
+  undeaddragon:
+    moonlight-dagger: Adaga do Luar
+    dragonclaw-shield: Escudo Garra-de-Dragão
+  desertofhellscar:
+    dragonbone-wand: Varinha de Osso de Dragão
+  apocalypse:
+    carmillas-kiss: Beijo de Carmilla
+    commodores-shield: Escudo do Comodoro
+    draconian-war-gauntlet: Manopla de Guerra Draconiana
+    emerald-claw-gauntlet: Manopla-Garra Esmeralda
+    improved-astral-shard: Fragmento Astral Aprimorado
+    improved-pact-blade: Lâmina do Pacto Aprimorada
+    improved-shadday-shield: Escudo Shadday Aprimorado
+    improved-shell-opener: Abre-Concha Aprimorado
+    improved-umbral-buckler: Broquel Umbral Aprimorado
+    kraken-slayer: Matador de Kraken
+    masterpiece-blade: Lâmina Obra-Prima
+    masterpiece-bow: Arco Obra-Prima
+    masterpiece-staff: Cajado Obra-Prima
+    outlander-shield: Escudo do Forasteiro
+    princess-bowaegis: Arco-Égide da Princesa
+    reality-render: Rasgador da Realidade
+    rod-of-the-prince: Cetro do Príncipe
+    standard-astral-shard: Fragmento Astral Padrão
+    standard-pact-blade: Lâmina do Pacto Padrão
+    standard-shadday-shield: Escudo Shadday Padrão
+    standard-shell-opener: Abre-Concha Padrão
+    standard-umbral-buckler: Broquel Umbral Padrão
+    ultimate-astral-shard: Fragmento Astral Definitivo
+    ultimate-pact-blade: Lâmina do Pacto Definitiva
+    ultimate-shadday-shield: Escudo Shadday Definitivo
+    ultimate-shell-opener: Abre-Concha Definitivo
+    ultimate-umbral-buckler: Broquel Umbral Definitivo
+  awakenings:
+    astral-symbol: Símbolo Astral
+    buckler: Broquel
+    azure-robins-knife: Faca do Robim Azul
+    defenders-buckler-back: Broquel do Defensor (Costas)
+    defenders-buckler-front: Broquel do Defensor (Frente)
+    heart-of-the-ocean: Coração do Oceano
+    heavy-shield: Escudo Pesado
+    hippocampus-banner: Estandarte do Hipocampo
+    holy-aegis: Égide Sagrada
+    improved-astral-symbol: Símbolo Astral Aprimorado
+    improved-heavy-shield: Escudo Pesado Aprimorado
+    improved-skull-piercer: Perfura-Crânio Aprimorado
+    improved-holy-aegis: Égide Sagrada Aprimorada
+    improved-buckler: Broquel Aprimorado
+    ominous-spearhead: Ponta de Lança Sinistra
+    skull-piercer: Perfura-Crânio
+    ultimate-astral-symbol: Símbolo Astral Definitivo
+    ultimate-heavy-shield: Escudo Pesado Definitivo
+    ultimate-skull-piercer: Perfura-Crânio Definitivo
+    ultimate-holy-aegis: Égide Sagrada Definitiva
+    ultimate-buckler: Broquel Definitivo

--- a/src/locales/pt_BR/keywords.yaml
+++ b/src/locales/pt_BR/keywords.yaml
@@ -1,1 +1,922 @@
----
+keyword:
+  - id: action-cubes-(ac)
+    keyword: CUBOS DE AÇÃO (CA)
+    description: |
+      Cubos coloridos gastos por Heróis para usar suas habilidades.
+  - id: activate
+    keyword: ATIVAR
+    description: |
+      Ativar é a instrução para tomar um turno. Assim, quando você Ativa um Monstro, por exemplo, você toma um turno com aquele Monstro: suas Condições são acionadas no início do turno, depois suas Aptidões Acionadas disparam e, por fim, ele realiza uma Ação de Movimento e/ou uma Ação de Ataque. Veja também: ATIVAR UM MASCOTE.
+  - id: activate-a-pet
+    keyword: ATIVAR UM MASCOTE
+    description: |
+      O Herói alvo ATIVA um de seus Mascotes (Ação de Movimento + Ataque). Se aquele Herói não tiver nenhum Mascote no tabuleiro, ele pode gastar esta ATIVAÇÃO para invocar um: pegue a carta do Mascote escolhido e coloque-a perto do painel daquele Herói e coloque o marcador (ou miniatura) daquele Mascote em uma Casa adjacente ao Herói. Mascotes ATIVAM gratuitamente uma vez por rodada, imediatamente após o turno de seu mestre (começando por aquela em que são invocados).
+  - id: adj-or-adjacent
+    keyword: ADJ OU ADJACENTE
+    description: |
+      Este efeito só pode afetar um Alvo em uma CASA adjacente ao Personagem conjurador, independentemente do Alcance da Habilidade.
+  - id: all
+    keyword: TODOS
+    description: |
+      Um efeito com este termo significa equivalente ao dano que o Alvo está recebendo. O efeito ainda se aplica apenas a um Alvo de um ataque, não a dois ou mais, durante MULTIALVO, TALHAR ou GOLPE.
+  - id: ambush
+    keyword: EMBOSCADA
+    description: |
+      O Monstro se teletransporta para qualquer casa desocupada adjacente ao seu alvo, à escolha desse alvo. Sofre efeitos do terreno onde pousa.
+  - id: area
+    keyword: ÁREA
+    description: |
+      Refere-se a um quadrado azul no tile do mapa contendo 4 CASAS pequenas.
+  - id: armor
+    keyword: ARMADURA
+    description: |
+      Sempre que um Monstro com esta habilidade for atingido por um <img src="/icons/2-melee-dmg.svg" class="inline-icon" alt="Melee Damage"> (e somente por este tipo de Ataque), PREVINA a quantidade indicada de dano causado a ele.
+  - id: attack-twice
+    keyword: ATACAR DUAS VEZES
+    description: |
+      Este Monstro ataca duas vezes durante o mesmo turno. Cada ataque é resolvido separadamente, o que significa que ele pode gerar mais de uma Ameaça. Mesmo atacando duas vezes, o Monstro tem apenas uma Ação de Movimento — então, se seu alvo sair de seu alcance Reagindo (<img src="/icons/reactions.svg" class="inline-icon" alt="Reactions">) ao primeiro Ataque, o Monstro não pode realizar o segundo. Se um Monstro com esta habilidade sofrer ATORDOAR, ele atacará apenas uma vez. Monstros “Travam” em seu alvo no início de sua ATIVAÇÃO, então, mesmo que o Herói alvejado pelo primeiro Ataque não seja mais o Alvo Principal do Monstro para o segundo, ele ainda atacará aquele Herói.
+  - id: aura
+    keyword: AURA
+    description: |
+      Um herói só pode ter uma e ela é removida quando o herói é NOCAUTEADO e recebe um CUBO DE TRAUMA. (Não é removida durante a Fase de Acampamento)
+  - id: aura-(token)
+    keyword: AURA (MARCADOR)
+    description: |
+      Como um efeito de Resolução, um Herói é frequentemente instruído a anotar uma Aura em seu Registro de Campanha ou Aplicativo Companheiro. Você pode manter este marcador em seu painel como um lembrete tátil e visual de que tem um efeito especial anotado ali. Marcadores de Aura são marcadores de Lembrete e foram introduzidos em Apocalypse.
+  - id: aura-of-sickness
+    keyword: AURA DA DOENÇA
+    description: |
+      No início do turno deste Monstro, acione a condição Veneno em todos os Heróis, Mascotes e Companheiros.
+  - id: available
+    keyword: DISPONÍVEL
+    description: |
+      Disponível refere-se mais a um termo de jogo do que necessariamente a uma Palavra-Chave. Uma Habilidade Disponível, por exemplo, é uma Habilidade aprendida por um Herói que não tem seu espaço atualmente ocupado (por um Cubo de Ação, Cubo de Maldição ou Cubo de Trauma). Uma Resolução Disponível, por sua vez, é uma Resolução que ainda não foi escolhida em uma Interação Carregada ou não foi declarada “indisponível” por algum efeito.
+  - id: avoid
+    keyword: EVITAR
+    description: |
+      Evitar não é propriamente uma Palavra-Chave, porém, é um novo termo em relação à Caixa Base, então vale esclarecer. “Evitar” é usado para indicar que você não sofre algum efeito, assim como PREVENIR faria, mas como PREVENIR é uma Palavra-Chave, foi necessária a adoção de um termo diferente.
+  - id: bash
+    keyword: PANCADA
+    description: |
+      Pancada é uma característica típica do Herói Andreas. Sempre que uma Habilidade tem Pancada, no momento em que você está prestes a resolver o efeito que contém a Palavra-Chave Pancada, você pode descartar 2 marcadores de Escudo. Se o fizer, adicione o efeito descrito entre os “[]” à resolução da sua Habilidade. Caso contrário, você deve resolver aquela Habilidade sem considerá-lo como parte do efeito.
+  - id: bear-trap
+    keyword: ARMADILHA DE URSO
+    description: |
+      Todos os inimigos na ÁREA recebem 2 de Dano não prevenível, SANGRAMENTO 2, DESCARTAR.
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/beartrap.png
+  - id: beginning-of-turn-(bot)
+    keyword: INÍCIO DO TURNO (IDT)
+    description: |
+      IDT é uma abreviação usada para descrever o momento de “Início do Turno”, quando algumas habilidades especiais dos Personagens são acionadas, logo após eles sofrerem os efeitos das Condições que possuem que também disparam no início de seu turno.
+  - id: bleed-x
+    keyword: SANGRAMENTO X
+    description: |
+      O Alvo recebe X marcadores de SANGRAMENTO. No início do próximo turno daquele personagem, ele recebe 1 de dano não prevenível para cada marcador de SANGRAMENTO que possui e então remove todos eles de seu painel. SANGRAMENTO é uma Condição EMPILHÁVEL.
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/bleed.png
+  - id: blink
+    keyword: PISCAR
+    description: |
+      Este Monstro se move através de realidades alternativas que encurtam seu caminho. Quando este Monstro realiza uma Ação de Movimento, ele se teletransporta para uma Casa adjacente ao seu alvo, escolhida por esse alvo, em vez de caminhar pelo tabuleiro.
+  - id: blindness
+    keyword: CEGUEIRA
+    description: |
+      Esta é uma habilidade especial que alguns Monstros possuem e que os torna inimigos muito perigosos. Quando um Personagem sofre CEGUEIRA, ele deve pegar um marcador de CEGO e mantê-lo em seu painel. Enquanto mantém um marcador de CEGO, o Personagem automaticamente erra qualquer ataque com arma se sua rolagem natural no d20 for 10 ou menos, mesmo que tenha sucesso no teste de Precisão de sua Arma. CEGUEIRA é uma Condição Redundante que dura até o Personagem tomar uma Ação de Recuperação ou ser removida por um efeito de PURIFICAR.
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/blind.png
+  - id: blood-feast
+    keyword: FESTIM DE SANGUE
+    description: |
+      Como um efeito de Dano Colateral, todos os Monstros deste tipo ganham permanentemente +1 DANO. Marque isso com um marcador de +1 DANO na carta deles.
+  - id: bloodseeker
+    keyword: CAÇADOR DE SANGUE
+    description: |
+      Um Monstro com Caçador de Sangue tem como Alvo Principal o Herói Mais Fraco (aquele com a menor Vida no momento).
+  - id: bounty
+    keyword: RECOMPENSA
+    description: |
+      Recompensa substitui e atualiza a Palavra-Chave “SAQUE” que os Companheiros tinham em Era das Trevas. Portanto, quando um Monstro é derrotado por um ataque que tem RECOMPENSA, aquele Monstro deixa cair um marcador de SAQUE quando removido do tabuleiro (marcadores de SAQUE são Objetos Móveis de Solo que podem ser coletados com uma Ação Menor; ao coletar Saque, um Herói compra uma carta de Baú, mas não rola o Dado de Armadilha).
+  - id: brittle
+    keyword: FRÁGIL
+    description: |
+      Alguns ataques são capazes de deixar seus oponentes vulneráveis. Quando um Personagem sofre Frágil, ele deve pegar um marcador de Frágil e mantê-lo em seu painel. Se for um Herói, Mascote ou Companheiro de qualquer tipo, na próxima vez que sofrer dano de qualquer fonte, sofrerá o dobro daquele dano e removerá seu marcador de Frágil (lembre-se, dano sofrido é o dano recebido que não foi prevenido). Se for um Monstro, o próximo ataque de arma ou magia que o acertar se torna um Acerto Crítico e remove seu marcador de Frágil. Frágil persiste até ser removida ou disparada conforme descrito. É uma Condição Redundante.
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/brittle.png
+  - id: burn-x
+    keyword: QUEIMADURA X
+    description: |
+      O Alvo recebe X marcadores de QUEIMADURA. No início do próximo turno daquele personagem, ele recebe 1 de dano não prevenível para cada marcador de QUEIMADURA que possui e então remove um desses marcadores de seu painel. QUEIMADURA é uma Condição EMPILHÁVEL.
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/burn.png
+  - id: cancel
+    keyword: CANCELAR
+    description: |
+      Cancelar é um termo que passou a estar associado às Interrupções devido à capacidade delas de responderem a um ataque enquanto ele está sendo desferido, em vez de depois que já atingiu seu alvo. Quando um ataque é Cancelado, isso significa que ele não existe mais e não causa mais dano a nenhum de seus alvos. Personagens que já usaram Interrupções para um ataque Cancelado ainda são considerados como tendo usado essas habilidades, mas depois que o ataque é Cancelado, nenhum outro Personagem pode usar uma Interrupção (e claro, nem Reações) contra aquele ataque.
+  - id: cast
+    keyword: CONJURAR
+    description: |
+      Este termo é usado para definir o momento em que um efeito é aplicado no jogo, frequentemente relacionado ao Personagem responsável por causá-lo. Assim, quando seu Herói gasta um de seus Cubos de Ação para usar uma Habilidade de Foco de Batalha, por exemplo, aquele Herói está conjurando um efeito FOCO 1 E PURIFICAR 1.
+  - id: catalyze
+    keyword: CATALISAR
+    description: |
+      Esta é uma Palavra-Chave projetada para condensar um efeito em uma única palavra, economizando espaço de texto. Quando um Herói Catalisa, significa que o próximo Cubo de Ação que ele usar neste turno (apenas o turno atual) é tratado como um Cubo Curinga (se for usado para acionar uma Habilidade de Herói, trate todos os números escritos em sua forma numérica como se fossem dobrados). Cubos Curinga podem ser usados como se fossem de qualquer cor, mas é importante lembrar que o Alcance dos efeitos de uma Habilidade ativada usando um Cubo Curinga é baseado no seu Tipo (ou seja, uma Habilidade Corpo a Corpo ativada por um Cubo Curinga ainda tem Alcance Corpo a Corpo).
+  - id: cd-collateral-damage
+    keyword: DC (DANO COLATERAL)
+    description: |
+      Este efeito é aplicado ao alvo de um Ataque se aquele Ataque reduzir com sucesso sua Vida. Descartar marcadores de ESCUDO não conta como reduzir a Vida.
+  - id: chain-up
+    keyword: ACORRENTAR
+    description: |
+      Monstros com esta habilidade se especializam em capturar Heróis. No início de seu turno, imediatamente após sofrer os efeitos de qualquer Condição que possa estar afetando-o, um Monstro com Acorrentar mira no Herói Mais Forte que não esteja adjacente e esteja dentro do Alcance 1 (se houver tal Herói). Aquele Herói sofre 2 de dano não prevenível e é arrastado para uma casa vazia à sua escolha que seja adjacente ao Monstro com Acorrentar. Se não houver espaço para ele, o Herói sofre 4 de dano não prevenível em vez de 2, mas não é arrastado.
+  - id: channel
+    keyword: CANALIZAR
+    description: |
+      Enquanto uma Habilidade com Canalizar tem um Cubo de Ação ocupando seu espaço (não quando está bloqueado por um Cubo de Maldição ou Cubo de Trauma), o bônus passivo descrito em “Canalizar - Efeito” tem efeito como se fosse uma Habilidade Passiva. Este benefício também é aplicado à própria Habilidade que o gerou. Dura até que este Cubo de Ação seja recuperado.
+  - id: character
+    keyword: PERSONAGEM
+    description: |
+      Heróis, Monstros, Mascotes, NPCs, Companheiros e assim por diante. Todos podem receber efeitos como PREVENIR, mas apenas personagens com cartas ou painéis podem manter Condições ou Recursos. Personagens são Objetos Sólidos Móveis para fins de regras.
+  - id: charge
+    keyword: INVESTIDA
+    description: |
+      "Alguns Monstros têm a habilidade de investir contra seus inimigos para maximizar seus ataques. Sempre que um Monstro com esta habilidade se move 3 ou mais casas para alcançar seu alvo, considere o valor de dano base deste ataque como se fosse o dobro. Lembre-se: os Monstros sempre se moverão a menor quantidade de casas possível para alcançar seus alvos ou buscar uma posição em cima da Escuridão. Apesar desta habilidade, os Monstros não são inteligentes o suficiente para pegar o caminho mais longo para alcançar seu alvo e receber este bônus. Seu comportamento permanece o mesmo: eles se movem o mínimo de casas possível até o alvo, a menos que possam terminar o movimento sobre a Escuridão ou evitar terreno prejudicial ao fazê-lo. O bônus de dano da Escuridão, bem como redutores de dano como Intimidar, são contados após este valor base ter sido determinado."
+  - id: charm
+    keyword: ENCANTAR
+    description: |
+      "Encantando a mente-simples de uma Criatura da Escuridão, um Herói pode forçá-la a atacar seus próprios aliados. Quando um Monstro é Encantado, o jogador que o enfeitiçou imediatamente ativa aquele Monstro e controla seu turno. Dessa forma, você pode forçá-lo a atacar seus próprios aliados, mover-se por terreno prejudicial ou posicioná-lo de forma desvantajosa ou ineficiente. No entanto, enquanto luta para manter o controle de sua própria mente, um Monstro está mais fraco: seu ataque causa apenas metade (arredondado para cima) do dano que causaria normalmente (dano colateral é aplicado normalmente). O bônus de dano da Escuridão, bem como redutores de dano como Intimidar, são contados após este valor base ter sido determinado."
+  - id: claim
+    keyword: RECLAMAR
+    description: |
+      Reclamar é um efeito típico do Senhor da Guerra, representando sua habilidade de coordenar os assaltos de seus aliados. Quando um Herói usa Reclamar, ele coloca (ou reposiciona) o Estandarte em uma casa vazia adjacente a ele. Enquanto sob a influência de um Estandarte, como uma Ação Menor, um Herói pode descartar um marcador de INSPIRAÇÃO para fazer um Ataque de Arma com +0 ACERTO. Para fins de regras, todas as casas adjacentes a um Estandarte são consideradas “Sob o Estandarte”. Por fim, Estandartes são Objetos Sólidos Móveis considerados Mobília e, portanto, podem ser esmagados por Monstros Grandes e causam 2 DANO E SANGRAMENTO 2 se forem arremessados contra um Personagem.
+  - id: cleanse-x
+    keyword: PURIFICAR X
+    description: |
+      O alvo remove até X Cubos de Maldição ou Pilhas de Condição de seu painel. Uma Pilha é: todos os marcadores do mesmo tipo que o Personagem possui. Para cada ponto de PURIFICAR recebido, aquele Personagem pode escolher remover um Cubo de Maldição ou uma Pilha de Condição. Ele não precisa gastar todos os pontos da mesma forma.
+  - id: cleave
+    keyword: TALHAR
+    description: |
+      Este <img src="/icons/2-melee-dmg.svg" class="inline-icon" alt="Melee Damage"> tem como alvo dois Personagens dentro do Alcance. Faça uma única rolagem de D20 para ambos os alvos.
+  - id: closest
+    keyword: MAIS PRÓXIMO
+    description: |
+      Monstros que têm o Herói Mais Próximo como Alvo Principal buscam o Herói que está fisicamente mais perto deles. Monstros que atacam Múltiplos Alvos ou áreas ainda priorizam atingir o maior número possível de Heróis, mas sempre escolhem os Mais Próximos entre as combinações que conseguem alcançar. Se dois ou mais Heróis estiverem à mesma distância de um Monstro, aquele que age primeiro na Trilha de Iniciativa é considerado o Herói Mais Próximo entre eles.
+  - id: color-blind-trait
+    keyword: DALTÔNICO (TRAÇO)
+    description: |
+      Você pode usar cubos de Agilidade para executar Habilidades à Distância e vice-versa. Quando você usa um cubo de Agilidade dessa forma, o efeito daquela Habilidade à Distância pode ter como alvo inimigos em qualquer lugar do tabuleiro, como se fosse uma Habilidade de Agilidade.
+  - id: command
+    keyword: COMANDAR
+    description: |
+      Ativa o próximo Monstro Mais Forte (não ele mesmo), então continua seu turno.
+  - id: command-a-draugr
+    keyword: COMANDAR UM DRAUGR
+    description: |
+      Comandar um Draugr significa ativar um Draugr de sua escolha que já está no tabuleiro. Diferente de outros Mascotes, Draugrs não podem ser “Erguidos” por um efeito de “Comandar” ou vice-versa. Para eles, esses efeitos agem independentemente. Além desse detalhe, Draugrs seguem as mesmas regras de um Mascote quanto aos seus turnos e para outros fins de regras.
+  - id: command-a-pet
+    keyword: COMANDAR UM MASCOTE
+    description: |
+      Comandar um Mascote é um efeito semelhante a Ativar um Mascote, com a restrição de que nunca pode ser usado para invocar um Mascote no tabuleiro. Assim, quando você Comanda um Mascote que invocou, você deve escolher um Mascote que já esteja no tabuleiro e que seja afiliado a você para Ativar.
+  - id: companions
+    keyword: COMPANHEIROS
+    description: |
+      Ativam-se após o herói que seguem, Mover e então Atacar. Só serão atacados se nenhum herói estiver no alcance. O número no canto superior esquerdo é a ROBUSTEZ. Podem manter ESCUDOS e receber efeitos de PREVENIR.
+  - id: copy-effect
+    keyword: COPIAR EFEITO
+    description: |
+      Copia o efeito de outra habilidade de Herói incluindo sua cor base (alcance). **Habilidades de Rolagem de Masmorra, Habilidades de Equipamento e Reações, salvo indicação em contrário, não podem ser copiadas.**
+  - id: counter
+    keyword: CONTRA-ATAQUE X
+    description: |
+      Este Monstro contra-ataca. Sempre que um Herói erra um <img src="/icons/2-melee-dmg.svg" class="inline-icon" alt="Melee Damage"> contra este Monstro, ele causa X de dano não prevenível a cada Herói, Mascote e Companheiro adjacente a ele.
+  - id: cover
+    keyword: COBRIR
+    description: |
+      Algumas habilidades protetoras que os Heróis possuem vão além de apenas mitigar dano; elas também podem mudar o alvo de um ataque. Quando um Personagem Cobre o alvo de um ataque, ele redireciona aquele ataque para si mesmo, tornando-se o novo alvo daquele ataque. Qualquer efeito de Prevenir que venha com um efeito de Cobrir também é redirecionado para o novo alvo daquele ataque. Se um ataque está mirando em você e em outro alvo ao mesmo tempo, você ainda pode Cobrir esse outro Personagem, mas sofrerá ambos os ataques como se tivesse sido alvo dele duas vezes.
+  - id: covetous
+    keyword: COBIÇOSO
+    description: |
+      Um Monstro com Cobiçoso tem como Alvo Principal o Herói que carrega mais marcadores de Recurso (FOCO, ESCUDO e KI são exemplos). Se dois Heróis estiverem empatados com o mesmo número de marcadores de Recurso, um Monstro com Cobiçoso mira naquele entre eles que ocupa o Espaço de Iniciativa mais rápido.
+  - id: crit-x
+    keyword: CRÍT X+
+    description: |
+      Rolar X ou mais no D20 dá Acerto Crítico (x2 DANO). Não inflige condições dobradas.
+  - id: cube-action-(ca)
+    keyword: AÇÃO COM CUBO (AC)
+    description: |
+      Gastar um CA. Um herói pode realizar 2 AC por turno e pode usar outras ações antes, entre ou depois de cada AC. Reações não contam.
+  - id: cube-range-(cr)
+    keyword: ALCANCE DO CUBO (AC)
+    description: |
+      Definido pela cor do cubo usado. Amarelo (Corpo a corpo) = Alvo em uma CASA adjacente. Vermelho (À distância) = Alvo em qualquer CASA até 1 ÁREA de distância. Verde (Agilidade) / Azul (Sabedoria) = Alvo a qualquer distância.
+  - id: curse-cubes-(cc)
+    keyword: CUBOS DE MALDIÇÃO (CM)
+    description: |
+      "Cubos pretos que são alocados em habilidades de Herói ou de Funções da Masmorra e bloqueiam seu uso. O Herói é corrompido ao receber um 6º CM e termina a aventura."
+  - id: curse-x
+    keyword: MALDIÇÃO X
+    description: |
+      O alvo ganha X CM como efeito.
+  - id: darkness-behavior
+    keyword: COMPORTAMENTO DA ESCURIDÃO
+    description: |
+      A Escuridão tenta chegar ao Herói Mais Forte que ainda não esteja em uma casa com Escuridão. “Esmagar”: Se todos os Heróis já estiverem sobre a Escuridão quando uma Runa for comprada, pule a geração do tile e todos os Heróis sofrem N de Dano. (N = Número de Heróis).
+  - id: darkness-effect-(standing-on-it)
+    keyword: EFEITO DA ESCURIDÃO (PISANDO NELA)
+    description: |
+      Uma vez por turno, causa 2 de Dano não prevenível a um Herói, Companheiro ou Mascote pego por ela ao ser gerada; que pisou nela pela primeira vez no turno; ou que terminou seu turno sobre ela. Heróis: Impõe uma penalidade de -2 ACERTO aos Heróis que estiverem sobre ela. Monstros ganham um bônus de +2 DANO enquanto estiverem sobre ela. Monstros sempre priorizam mover-se para a Escuridão quando é possível atingir seu alvo a partir dela.
+  - id: decayed
+    keyword: DECAÍDO
+    description: |
+      A vida deste Monstro é passageira. Quando ele realiza uma Ação de Ataque, após resolvê-la, ele é morto.
+  - id: defiant
+    keyword: DESAFIADOR
+    description: |
+      Um Monstro com Desafiador tem como Alvo Principal o Herói Mais Vigoroso (aquele com mais Cubos de Ação disponíveis no momento).
+  - id: devourer
+    keyword: DEVORADOR
+    description: |
+      "Monstros com esta habilidade mostram comportamento atípico. Priorizam procurar por presas em vez de vítimas. Portanto, tais Monstros têm marcadores de NPC Ferido como seu Alvo Principal em vez dos Heróis. Quando atacam um desses marcadores, imediatamente os massacram, saciando sua sede de sangue. Isso, porém, não é uma coisa boa: Depois de fazerem isso, esses Monstros completam seu propósito e seus corpos passam por uma mutação hedionda. Substitua o modelo de Carne Apodrecida por um modelo de Abominação e vire a carta de Devorador Instável. Ele ganha 12 de Vida (esta Vida pode exceder seu total máximo) e se torna uma Abominação Voraz. Se não houver NPCs Feridos no tabuleiro (se seu grupo já os resgatou todos, por exemplo) o comportamento deste Monstro muda para o padrão: o Herói Mais Forte no alcance."
+  - id: difficult-terrain
+    keyword: TERRENO DIFÍCIL
+    description: |
+      Um personagem afetado por Terreno Difícil (como Água) perde 1 ponto de movimento do seu efeito de movimento atual. Como em qualquer terreno prejudicial, um personagem só pode ser afetado por Terreno Difícil uma vez por turno.
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/dificultterrain.png
+  - id: disarm
+    keyword: DESARMAR
+    description: |
+      (Conta como FADIGA) GASTAR todos os CA disponíveis de Corpo a corpo e À distância.
+  - id: discard
+    keyword: DESCARTAR
+    description: |
+      Um cubo é considerado DESCARTADO quando um Herói o move diretamente para sua Caixa de Cubos Gastos por qualquer motivo (geralmente como FADIGA ou como custo de tomar Ações Menores extras).
+  - id: drain-health
+    keyword: DRENAR VIDA
+    description: |
+      O alvo perde X pontos de vida e o conjurador os ganha. Reações não podem ser usadas.
+  - id: drunk-trait
+    keyword: BÊBADO (TRAÇO)
+    description: |
+      O álcool está correndo pelo seu corpo. Pegue 3 marcadores de Tempo e coloque-os no seu painel de Herói. No início de cada um dos seus próximos turnos, remova 1 desses marcadores (este é um efeito de Início de Turno, resolvido antes de o dano de Condição ser aplicado). Quando o último marcador for removido, você não está mais BÊBADO.
+  - id: empower
+    keyword: FORTALECER
+    description: |
+      Concentrando sua energia, você se prepara para desferir um poderoso golpe. Quando você Fortalece, o próximo único Ataque de Arma ou Ataque Mágico que você fizer neste turno ganha +4 DANO. Note que este efeito dura apenas até o final deste turno ou quando você fizer seu próximo Ataque de Arma ou Ataque Mágico (mesmo que erre), o que ocorrer primeiro. Se um efeito permitir que você faça dois ou mais Ataques de Arma separados como parte da mesma Ação, o efeito de Fortalecer só é aplicado ao primeiro deles (Talhar é um único golpe que afeta dois ou mais alvos, então este bônus se aplica a todos eles).
+  - id: end-of-turn-(eot)
+    keyword: FIM DO TURNO (FDT)
+    description: |
+      "FDT é uma abreviação usada para descrever o momento de “Fim do Turno”, quando alguns efeitos são disparados, como aqueles que duram até o fim do turno do Personagem. O Fim do Turno é exatamente a última coisa que acontece em um turno, antes do Marcador de Iniciativa 81 ser avançado: ele dispara logo após um Herói ter completado todas as suas Ações e escolher tomar ou não uma Ação de Recuperação Voluntária. Se algum efeito disparar por causa desta Ação de Recuperação, o Fim do Turno ocorre imediatamente após a resolução daquele efeito"
+  - id: enemy
+    keyword: INIMIGO
+    description: |
+      Qualquer personagem que não esteja em seu grupo ou um NPC. Os heróis são inimigos dos monstros.
+  - id: engaged
+    keyword: ENGAJADO
+    description: |
+      Quando um Personagem está adjacente a um Inimigo. Ataques à Distância e a maioria das Ações Menores não são permitidos.
+  - id: enrage
+    keyword: ENFURECER
+    description: |
+      Alguns Monstros têm um gosto por batalha que cresce à medida que causam ferimentos em seus inimigos. Sempre que um Monstro que possui essa habilidade como Dano Colateral puder reduzir a Vida de um Personagem ou remover um Personagem Especial (Mascote, Companheiro ou qualquer outro tipo de aliado) do jogo com um ataque, ele ganha um marcador de +1 DANO. Se o Monstro tiver Atacar Duas Vezes, o segundo ataque feito em sua ativação pode causar mais dano, já que este Monstro pode receber um marcador de +1 DANO como resultado do primeiro ataque.
+  - id: entropy
+    keyword: ENTROPIA
+    description: |
+      "Especialistas em conjuração podem provocar transformações miraculosas em suas magias liberando grandes quantidades de energia. Sempre que fazem isso, a oscilação de energia resultante desse processo gera o que chamamos de Entropia Arcana, ou apenas Entropia. Quando um Herói tem 4 desses marcadores, ele pode descartá-los para provocar uma Explosão de Entropia e fazer uma de duas coisas: Como uma Ação Menor, ganhar uma Ação com Cubo adicional neste turno; ou ganhar uma Reação adicional contra a Ameaça atual. Entropia é um marcador de Recurso EMPILHÁVEL."
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/entropy.png
+  - id: evolve
+    keyword: EVOLUIR
+    description: |
+      O Monstro ganha +2 DANO e +1 MOVIMENTO. Use os marcadores correspondentes para acompanhar isso no painel do Monstro.
+  - id: expend
+    keyword: GASTAR
+    description: |
+      Mova um CA disponível para a caixa de CA Gasto no painel do herói. CA Gasto pode ser recuperado, mas não pode ser usado para habilidades enquanto estiver lá.
+  - id: falling-damage
+    keyword: DANO DE QUEDA
+    description: |
+      O Personagem sofre 2 de Dano não prevenível ao descer dois níveis em um único passo.
+  - id: farthest
+    keyword: MAIS DISTANTE
+    description: |
+      Monstros que têm o Herói Mais Distante como Alvo Principal buscam o Herói que está fisicamente mais longe deles, mas ainda ao seu alcance. Monstros que atacam Múltiplos Alvos ou áreas ainda priorizam atingir o maior número possível de Heróis, mas sempre escolhem os Mais Distantes entre as combinações que conseguem alcançar. Se um desses Monstros tiver a opção de atingir o segundo Herói Mais Distante junto com outro Herói ou Mascote em vez de atingir apenas o Herói Mais Distante, ele prioriza o primeiro cenário. Se dois ou mais Heróis estiverem à mesma distância de um Monstro, aquele que age por último na Trilha de Iniciativa é considerado o Herói Mais Distante entre eles. Se o Monstro não conseguir alcançar nenhum Herói, ele se move em direção ao Herói Mais Distante em Qualquer Alcance.
+  - id: fatigue-x
+    keyword: FADIGA X
+    description: |
+      O Alvo deve GASTAR X (ou quantos for possível) de seus CA disponíveis sem efeito.
+  - id: fe-fatality-effect
+    keyword: EF (EFEITO DE FATALIDADE)
+    description: |
+      Efeitos de Fatalidade, assim como o Dano Colateral, são Efeitos Acionados ligados a um ¹ ou ². Aplique o efeito descrito se o Ataque matar seu alvo.
+  - id: fire-trap
+    keyword: ARMADILHA DE FOGO
+    description: |
+      Todos os inimigos na ÁREA recebem 2 de Dano não prevenível, QUEIMADURA 4, DESCARTAR.
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/firetrap1.png
+  - id: firebreather-trait
+    keyword: CUSPIDOR DE FOGO (TRAÇO)
+    description: |
+      Sua garganta está em chamas e é uma pena guardar essa sensação só para você. Como uma Ação Menor, você pode expelir uma bola de fogo que causa 4 ¹ DANO COM ‘DC – QUEIMADURA 2’ a cada Personagem em qualquer Área em Qualquer Alcance à sua escolha. Monstros Grandes alvejados por esta bola de fogo sofrem o efeito duas vezes (8 ¹ DANO COM DC – QUEIMADURA 4).
+  - id: flyby
+    keyword: VOO RASANTE
+    description: |
+      Este mascote retorna para uma CASA à sua escolha adjacente ao seu mestre após atacar. Só é afetado por terreno/Escuridão depois de pousar.
+  - id: focus-x
+    keyword: FOCO X
+    description: |
+      O Alvo ganha X marcadores de FOCO, que ele pode gastar posteriormente para usar Habilidades de Foco. FOCO é um recurso EMPILHÁVEL.
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/focus.png
+  - id: free-recall-action
+    keyword: AÇÃO DE RECUPERAÇÃO GRÁTIS
+    description: |
+      O Herói toma uma AÇÃO DE RECUPERAÇÃO sem sofrer penalidade de CM.
+  - id: fruit-of-life
+    keyword: FRUTO DA VIDA
+    description: |
+      "Com uma Ação Menor de Usar Item Consumível, um Personagem carregando um FRUTO DA VIDA pode descartá-lo para: EM SI, RECUPERAR 2 DE VIDA. Além disso, esses frutos são considerados itens e podem ser trocados com outros Heróis como qualquer outro item normalmente seria, mas não ocupam nenhum espaço na mochila. FRUTO DA VIDA é um recurso EMPILHÁVEL."
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/fruit_of_life.png
+  - id: fury
+    keyword: FÚRIA
+    description: |
+      Quando você acerta com um Ataque Mágico ou Ataque de Arma, pode descartar 1 FÚRIA para adicionar +1 DANO ao seu Ataque. Você pode descartar apenas 1 marcador de FÚRIA por turno ou Reação (se tiver uma habilidade que também seja uma Reação, por exemplo). FÚRIA é um recurso EMPILHÁVEL. *Apocalypse atualizou FÚRIA da seguinte forma:* Quando você acerta com um Ataque Mágico ou Ataque de Arma, pode descartar 1 FÚRIA para adicionar +1 DANO ao seu Ataque (nenhuma ação é necessária). Você pode descartar 1 marcador de FÚRIA para cada Ataque de Arma ou Ataque Mágico individual que fizer, o que pode ser mais de uma vez por turno. FÚRIA é um recurso EMPILHÁVEL. **NOTA:** Sempre que você descartar 1 Fúria para reforçar um ataque que tem mais de um Personagem como alvo de uma só vez (TALHAR e GOLPE, por exemplo), o dano bônus é aplicado a cada alvo. Você não precisa descartar 1 marcador de Fúria para cada Personagem alvo dessa forma.
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/Fury.png
+  - id: gain-a-x-bonus
+    keyword: GANHAR UM BÔNUS DE +X
+    description: |
+      Sempre que o Herói conjurar um efeito com a Palavra-Chave relevante, aquele efeito ganha o número apropriado de pontos adicionais. Por exemplo, se um Herói conjura um efeito CURAR 2 e tem uma habilidade que concede um bônus de +1 a cada efeito CURAR que ele conjura, o efeito se torna CURAR 3.
+  - id: guard
+    keyword: DEFENDER
+    description: |
+      O Personagem que conjura sofre o dano que o Personagem alvo teria sofrido. Efeitos de PREVENIR ligados a esta Palavra-Chave protegem o novo alvo do Ataque.
+  - id: heal
+    keyword: CURAR
+    description: |
+      Restaura Pontos de Vida ao Personagem alvo. Como regra, Personagens não podem recuperar mais Pontos de Vida do que seu máximo. “Curas excedentes” são desperdiçadas.
+  - id: heal-x
+    keyword: CURAR X
+    description: |
+      O Alvo recupera X de Vida que não pode exceder a Vida máxima.
+  - id: healthy
+    keyword: SAUDÁVEL
+    description: |
+      Saudável é um estado de saúde em que os Personagens podem estar. Personagens que têm metade ou mais (arredondado para cima) de seus Pontos de Vida máximos são considerados Saudáveis. Algumas habilidades interagem com Personagens nessas condições.
+  - id: heavy-wield
+    keyword: EMPUNHADURA PESADA
+    description: |
+      Armas que têm a propriedade Empunhadura Pesada são mais difíceis de manusear, mas geralmente causam mais dano quando acertam. Enquanto você estiver equipado com uma Arma que tem Empunhadura Pesada, você pode fazer apenas um único Ataque de Arma de cada ação de Ataque de Arma que tomar ou receber. Assim, você não pode fazer dois Ataques de Arma de uma única Ação com Cubo (como faria com a Habilidade Golpe Duplo, por exemplo), Habilidade de Foco, Habilidade de Classe ou Comando que tomar ou receber ao usar essas armas. Mas você pode, por exemplo, fazer um Ataque de Arma por meio de cada uma de suas duas Ações com Cubo e um terceiro por meio de sua Habilidade de Foco ou gastando um marcador de KI.
+  - id: idol
+    keyword: ÍDOLO
+    description: |
+      Ídolos são figuras que possuem propriedades mágicas que os Heróis podem invocar para ajudá-los em batalha. Quando um Ídolo é Invocado, o Herói coloca ou reposiciona (se aquele Ídolo já estiver no tabuleiro) seu marcador correspondente na interseção central da área (quadrado azul) em que ele está ou em uma área adjacente a ela. Note que apenas Invocar um Ídolo não ativa seus efeitos imediatamente (Xamãs têm uma habilidade de classe que permite fazer isso como um poder especial). Uma vez colocado, o Ídolo é considerado um Objeto de Solo Imóvel, ou seja, não pode ser movido por nenhum meio, incluindo Telecinese. Cada Ídolo tem um poder que pode ser Evocado por qualquer Herói (não apenas pelo conjurador) dentro do Alcance 1 daquele Ídolo usando uma Ação Menor e gastando qualquer combinação de 2 marcadores de Recurso
+  - id: immunity
+    keyword: IMUNIDADE
+    description: |
+      Este personagem não pode ser afetado pelas condições/efeito. Imunidade a Furtividade significa que ele pode mirar naquela unidade e não pode ser surpreendido (x2 DANO).
+  - id: inflict
+    keyword: INFLIGIR
+    description: |
+      Este é o termo usado para designar um efeito (geralmente Condições) aplicado por um Personagem conjurador contra um Personagem alvo sem lhe dar chance de se defender, similar ao que dano não prevenível faria. Assim, um efeito Infligido não gera nenhum Ataque ou Ameaça (mesmo que venha de uma carta de Ataque, por exemplo), não permitindo que os Personagens usem suas Interrupções e Reações para se defender. Lembre-se, se um Personagem for imune a uma Condição, naturalmente, tal Condição não o afeta quando é Infligida sobre ele.
+  - id: inspire
+    keyword: INSPIRAR
+    description: |
+      Representando um impulso de moral, quando um Herói se torna Inspirado, ele recebe um marcador de Inspiração. Ao descartar um desses marcadores (nenhuma ação é necessária) um Herói pode rerrolar qualquer rolagem de d20 que acabou de fazer, ficando com o segundo resultado mesmo que seja menor que o primeiro. Inspiração é um Recurso redundante.
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/inspiration.png
+  - id: interact
+    keyword: INTERAGIR
+    description: |
+      Interações são situações que acontecem durante uma Aventura nas quais seu Herói pode (ou deve) intervir. Algumas Interações serão apresentadas ao seu grupo por meio de efeitos no jogo, mas a maioria delas será encontrada no tabuleiro como marcadores de Interação.
+  - id: intimidate-x
+    keyword: INTIMIDAR X
+    description: |
+      O Personagem tem -X DANO para cada marcador de INTIMIDAR que estiver carregando. Diferente de outras Condições, INTIMIDAR não tem efeito no início do próximo turno, ele persiste até ser removido. Na próxima vez que o personagem afetado fizer um Ataque (seja um Ataque de Arma ou um Ataque Mágico), acerte ou erre, ele remove todos os marcadores de INTIMIDAR que está carregando. INTIMIDAR é uma Condição EMPILHÁVEL.
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/intimidate.png
+  - id: interrupt
+    keyword: INTERRUPÇÃO
+    description: |
+      Estas são reações alternativas, mais rápidas, porém únicas. A janela para um Herói usar uma INTERRUPÇÃO ocorre no momento em que um Ataque (seja de um Monstro, de um Chefe ou de uma carta de Ataque de Comandante) tem como alvo um Herói, Mascote ou Companheiro. O Herói usa a INTERRUPÇÃO e aplica seus efeitos antes que o dano do Ataque seja causado e que os marcadores de ESCUDO sejam gastos. Quando um Herói usa uma INTERRUPÇÃO, ele não pode usar Reações (³) para responder a Ameaças acionadas pelo Ataque que interrompeu.
+  - id: jump-x
+    keyword: SALTAR X
+    description: |
+      Mesmo que MOVER X, mas afetado apenas pelo terreno onde pousa e pode passar por inimigos. Não afetado por DANO DE QUEDA. Subir 2 níveis ainda custa 2 de movimento.
+  - id: keen
+    keyword: AGUÇADO
+    description: |
+      O limiar de Acerto Crítico para este <img src="/icons/2-melee-dmg.svg" class="inline-icon" alt="Melee Damage"> é aumentado para Natural 16+. “Natural” se refere ao valor rolado no D20, ignorando quaisquer bônus ou penalidades.
+  - id: ki
+    keyword: KI
+    description: |
+      Você pode descartar um KI para fazer um Ataque de Arma com +0 ACERTO. Independentemente de ter gasto um KI para fazer um Ataque de Arma ou para usar qualquer outra habilidade que tenha aprendido, você só pode descartar um KI por turno ou Reação (se tiver uma habilidade que também seja uma Reação, por exemplo). KI é um recurso EMPILHÁVEL.
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/ki.png
+  - id: killing-blow
+    keyword: GOLPE MORTAL
+    description: |
+      O Golpe Mortal é o ataque (e neste caso é necessariamente um ataque; dano de Condição não conta, por exemplo) responsável por derrotar o Monstro. Se um efeito Abate um Personagem, naturalmente ele também desfere o Golpe Mortal, já que o termo Abater especifica que ele derrota o Personagem mesmo sem reduzir sua Vida a 0.
+  - id: knock-down
+    keyword: DERRUBAR
+    description: |
+      DERRUBAR é uma Condição Debilitante. Quando um Personagem sofre DERRUBAR, ele pega o marcador apropriado e o coloca em seu painel. No início de seu próximo turno, ele descarta o marcador de DERRUBAR e perde sua Ação de Movimento naquele turno. Heróis ainda podem tomar Ações de Movimento adicionais seguindo as regras apropriadas, mas Monstros só poderão atacar se houver um Herói ao alcance. DERRUBAR é uma Condição Redundante (apenas 1 instância por vez).
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/knock_down.png
+  - id: large-monster
+    keyword: MONSTRO GRANDE
+    description: |
+      Este Monstro é considerado Grande (mesmo que sua base seja de tamanho pequeno). Um Monstro Grande é imune a DERRUBAR, EMPURRAR, ATORDOAR e TELECINESE.
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/large_monster.png
+  - id: learn
+    keyword: APRENDER
+    description: |
+      Quando seu Herói aprende uma Habilidade de Herói de Nível 1, ele deve escolher uma Habilidade de Nível 1 de seu Herói, pegar sua respectiva carta e Cubo de Ação e adicioná-los ao seu Painel de Herói. <br /><br /> **NOTA:** É importante lembrar que um Herói não pode Aprender uma Habilidade de Herói de Nível 2 se não tiver aprendido uma Habilidade de Nível 1 pertencente àquela mesma Árvore de Habilidades. Quando um Herói aprende uma Aptidão de Classe, ele pega um Cubo Branco. Ele coloca a carta ao lado de seu painel e o cubo no espaço apropriado para marcar a Aptidão de Classe que aprendeu. <br /><br /> **NOTA:** Da mesma forma, é importante lembrar que um Herói não pode Aprender uma Aptidão de Classe de Nível 2 ou 3 se não tiver aprendido uma Aptidão de Classe de Nível 1 ou 2 (respectivamente) pertencente àquela mesma Árvore de Classe.
+  - id: loot
+    keyword: SAQUE
+    description: |
+      Quando este Monstro é derrotado, substitua sua miniatura por um Baú. Ele é seguro (sem dado de Armadilha ao abrir).
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/loot.png
+  - id: loot-(tokens)
+    keyword: SAQUE (MARCADORES)
+    description: |
+      "Marcadores de Saque são Objetos Móveis de Solo que podem ser recolhidos por Heróis adjacentes ou em cima deles com uma Ação Menor. Quando o fazem, compram a carta do topo do baralho de Baú, mas não precisam rolar o Dado de Armadilha: o Saque é sempre seguro. Como em um Baú, no momento em que um Herói compra um Item Consumível, pode escolher usá-lo imediatamente como uma ação livre. Caso contrário, mantém aquela carta em sua mochila."
+  - id: maelstrom
+    keyword: MAELSTROM
+    description: |
+      Na ativação do Suserano, você embaralha suas cartas de Ataque de volta no baralho e compra um novo conjunto (uma por Herói).
+  - id: manifest
+    keyword: MANIFESTAR
+    description: |
+      Pegue aleatoriamente uma Runa da sacola e revele-a, disparando o efeito. Não gera Escuridão e é colocada de volta na sacola.
+  - id: mark
+    keyword: MARCA
+    description: |
+      MARCA é uma Condição Debilitante. Quando um Personagem sofre MARCA, ele pega o marcador apropriado e o coloca em seu painel. A partir desse momento, qualquer <img src="/icons/2-melee-dmg.svg" class="inline-icon" alt="Melee Damage"> feito pelo dono da MARCA contra aquele Personagem ganha um bônus de +1 DANO. MARCA é uma Condição Redundante (apenas 1 instância por vez).
+  - id: mending-x
+    keyword: RESTAURAR X
+    description: |
+      Monstros com esta habilidade são médicos de campo a serviço do inimigo, mantendo seus aliados prontos para outra rodada. Quando esta habilidade é disparada, outro Monstro mais fraco (o Monstro com a menor Vida no momento) dentro do alcance 1 do Monstro conjurador recupera X de Vida (esta Vida não pode exceder seu máximo). Se dois ou mais Monstros estiverem empatados, aquele que ocupa o espaço de cor mais alto no painel de Status do Monstro entre eles será o alvo escolhido (amarelo é mais alto que azul-escuro, por exemplo). Se não houver outro Monstro dentro do Alcance 1 do conjurador, um Monstro não pode usar Restaurar em si mesmo.
+  - id: mindlock
+    keyword: BLOQUEIO MENTAL
+    description: |
+      Monstros com esta habilidade são capazes de interferir nos pensamentos dos Heróis apenas por estarem em sua presença. Enquanto um Monstro com esta habilidade estiver no tabuleiro, nenhum Herói pode gastar Cubos de Ação (azuis) de Sabedoria para usar Habilidades. Eles ainda podem Gastar esses cubos para tomar Ações de Desempate, Ações Menores adicionais, Ações de Movimento adicionais e assim por diante.
+  - id: most-corrupted
+    keyword: MAIS CORROMPIDO
+    description: |
+      Monstros que têm o Herói Mais Corrompido como Alvo Principal buscam o Herói com o maior número de Cubos de Maldição naquele momento. Monstros que atacam Múltiplos Alvos ou áreas ainda priorizam atingir o maior número possível de Heróis, mas sempre escolhem os Mais Corrompidos entre as combinações que conseguem alcançar. Se um desses Monstros tiver a opção de atingir o segundo Herói Mais Corrompido junto com outro Herói ou Mascote em vez de atingir apenas o Herói Mais Corrompido, ele prioriza o primeiro cenário. Se dois ou mais Heróis tiverem o mesmo número de Cubos de Maldição, aquele que age por último na Trilha de Iniciativa é considerado o Herói Mais Corrompido entre eles.
+  - id: most-tired-hero
+    keyword: HERÓI MAIS CANSADO
+    description: |
+      O Herói com menos Cubos de Ação disponíveis é o Herói Mais Cansado. Se dois Heróis estiverem empatados com o mesmo número de Cubos de Ação disponíveis, aquele que age por último na Trilha de Iniciativa é considerado o Mais Cansado entre eles.
+  - id: most-vigorous-hero
+    keyword: HERÓI MAIS VIGOROSO
+    description: |
+      O Herói com mais Cubos de Ação disponíveis é o Herói Mais Vigoroso. Se dois Heróis estiverem empatados com o mesmo número de Cubos de Ação disponíveis, aquele que age primeiro na Trilha de Iniciativa é considerado o Mais Vigoroso entre eles.
+  - id: move-x
+    keyword: MOVER X
+    description: |
+      O Alvo pode se mover até X CASAS ortogonal ou diagonalmente. Não pode passar por OBJETOS SÓLIDOS ou INIMIGOS, mas pode passar por aliados sem parar sobre eles. O movimento pode ser interrompido para fazer uma Ação Menor e então continuado, mas usar uma CA ou REAÇÃO fará perder os pontos de movimento restantes.
+  - id: multishot
+    keyword: MULTIALVO
+    description: |
+      Este <img src="/icons/2-melee-dmg.svg" class="inline-icon" alt="Melee Damage"> tem como alvo dois Personagens dentro do Alcance. Faça uma única rolagem de D20 para ambos os alvos.
+  - id: non-preventable
+    keyword: NÃO PREVENÍVEL
+    description: |
+      Este dano não pode ser prevenido por nenhum tipo de efeito, incluindo ESCUDO e/ou PREVENIR. Dano não prevenível não é considerado uma ameaça e, portanto, não pode ter Reações usadas contra ele.
+  - id: npc
+    keyword: NPC
+    description: |
+      NPC (Personagens Não Jogadores) são os coadjuvantes de uma Campanha. Alguns Marcadores de NPC são usados para representar seus Companheiros no tabuleiro, enquanto outros apenas incorporam NPCs genéricos como "Aldeões" ou "Crianças". De qualquer forma, um Marcador de NPC é um Objeto Sólido e sempre que são usados, seguem um conjunto de regras especiais próprias. Cada Aventura descreverá exatamente como esses marcadores interagem com os jogadores e a Aventura atual.
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/npc.png
+  - id: object
+    keyword: OBJETO
+    description: |
+      Armadilhas, tiles de Escuridão ou outros especificados como tal. Personagens podem passar por cima e terminar o movimento neles.
+  - id: outcome
+    keyword: DESFECHO
+    description: |
+      Só é apagado quando comandado pela resolução de outra Interação.
+  - id: overpressure
+    keyword: SOBREPRESSÃO
+    description: |
+      Alguns Monstros possuem energia arcana tão poderosa que distorcem o espaço-tempo e frequentemente emanam vibrações perturbadoras. Portanto, enquanto um Monstro com esta habilidade estiver no tabuleiro, nenhum Herói pode tomar Ações Menores exceto “Usar Item Consumível” se estiver tomando essa ação para beber uma poção.
+  - id: passive
+    keyword: PASSIVA
+    description: |
+      A habilidade está sempre ativa (incluindo cartas de Ataque de Comandante) a menos que bloqueada por CUBO DE TRAUMA ou CUBO DE MALDIÇÃO.
+  - id: pay-x-life
+    keyword: PAGAR X DE VIDA
+    description: |
+      O Herói sofre X de Dano para aplicar os benefícios. Não pode usar se X > Vida atual.
+  - id: penitence
+    keyword: PENITÊNCIA
+    description: |
+      O Alvo recebe 1 de Dano não prevenível por CUBO DE MALDIÇÃO em seu painel.
+  - id: pet
+    keyword: MASCOTE
+    description: |
+      Mascotes são aliados que alguns Heróis invocam para ajudá-los em batalha. Cartas de Mascote não são colocadas na Trilha de Iniciativa. Eles sempre ATIVAM imediatamente após o turno de seu mestre, antes de o marcador avançar para a próxima carta da trilha. Quando um Mascote ativa já estando no tabuleiro, ele realiza uma Ação de Movimento (pode escolher mover 0 casas) e então realiza um Ataque. Mascotes causam diretamente o Dano mostrado em sua carta. Eles não precisam fazer Testes de Precisão. Monstros só alvejam Mascotes quando não conseguem atacar um Herói. Mascotes têm apenas 1 Ponto de Vida, mas podem receber marcadores de ESCUDO e efeitos de PREVENIR normalmente. Quando um Mascote morre, ele é dispensado. Remova sua miniatura do tabuleiro. Ele pode ser invocado novamente mais tarde.
+  - id: poison
+    keyword: VENENO
+    description: |
+      VENENO é uma Condição de Dano Persistente. Quando um Personagem sofre VENENO, ele pega o número apropriado de marcadores e os coloca em seu painel. No início de seu turno, ele sofre 1 de dano não prevenível para cada marcador de VENENO que possui. VENENO é uma Condição EMPILHÁVEL (até 4 instâncias).
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/poison.png
+  - id: poison-trap
+    keyword: ARMADILHA DE VENENO
+    description: |
+      Todos os inimigos na ÁREA recebem 2 de Dano não prevenível, VENENO 2, DESCARTAR.
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/poisontrap.png
+  - id: predator
+    keyword: PREDADOR
+    description: |
+      Monstros com esta habilidade possuem os instintos de um assassino. Dobre o poder base dos Ataques deste Monstro contra Heróis que tenham metade ou menos (arredondado para baixo) de seus Pontos de Vida máximos (ou seja, um Herói Ferido). Por exemplo, se o Monstro tem poder base 4, ele se torna 8 ao Atacar um Herói nessas condições.
+  - id: prevent
+    keyword: PREVENIR
+    description: |
+      PREVENIR está associado a Reações (<img src="/icons/reactions.svg" class="inline-icon" alt="Reactions">) e é usado para mitigar o dano que está sendo causado por uma Ameaça. PREVENIR não pode reduzir dano descrito como “não prevenível”.
+  - id: primary-target
+    keyword: ALVO PRINCIPAL
+    description: |
+      O Alvo Principal de um Monstro é o personagem que ele busca atacar durante seu turno. Se o Monstro não conseguir alcançar seu Alvo Principal, ele se move em direção a ele.
+  - id: protect
+    keyword: PROTEGER
+    description: |
+      Este personagem se torna o Alvo, a menos que já seja um Alvo devido a TALHAR, MULTIALVO ou GOLPE.
+  - id: push-x
+    keyword: EMPURRAR X
+    description: |
+      Empurre o Alvo X CASAS para longe do Conjurador em linha reta. Deve ser empurrado toda a extensão.
+  - id: pushback
+    keyword: EMPURRÃO PARA TRÁS
+    description: |
+      Este efeito é semelhante ao Empurrar, mas é uma versão adaptada para ser usada por Monstros. Quando um Personagem sofre Empurrão para Trás, ele deve empurrar seu modelo 1 casa para trás, ou seja, mais longe da fonte que o empurrou. Efetivamente, ele terá três casas para as quais pode ser empurrado. Um Personagem que sofreu Empurrão para Trás deve sempre escolher um espaço desocupado onde possa ser empurrado, mesmo que seja um terreno prejudicial ou se tiver de sofrer dano de queda por ter sido empurrado de um nível 2 para 0 da bandeja da masmorra. Se todas as casas possíveis estiverem ocupadas por Objetos Sólidos, o Personagem não pode ser empurrado.
+  - id: quick-attack
+    keyword: ATAQUE RÁPIDO
+    description: |
+      O ataque deste Monstro não gera Ameaça. Portanto, os Heróis não podem usar Reações ou Interrupções para responder a ele.
+  - id: raise
+    keyword: ERGUER
+    description: |
+      No início do turno deste Monstro, gere X Lacaios em casas adjacentes a ele. Se não houver miniaturas de Monstros suficientes, gere o máximo possível e ATIVE um deles.
+  - id: raise-a-draugr
+    keyword: ERGUER UM DRAUGR
+    description: |
+      Reutilizando a energia maligna usada pela Escuridão para criar suas Criaturas, Necromantes podem criar um exército próprio. Erguer um Draugr significa colocar um deles em uma casa vazia à sua escolha adjacente a você, leal ao Necromante que o invocou. Diferente de outros Mascotes, Draugrs não podem ser “Erguidos” por um efeito de “Comandar” ou vice-versa. Da mesma forma, o efeito genérico de “Ativar um Mascote de sua escolha” não funciona para Erguer ou Comandar. Apenas os efeitos específicos de Erguer um Draugr e Comandar um Draugr afetam essas criaturas. Além desse detalhe, Draugrs seguem as mesmas regras dos Mascotes quanto aos seus turnos e outros fins de regras. Se todos os quatro Draugrs já estiverem no tabuleiro, um Necromante não pode mais Erguê-los, apenas Comandá-los (note que, diferente de outros Mascotes, um efeito que permite Erguer um Draugr não permite Comandar um Draugr—esses são efeitos separados para o Necromante). **NOTA:** Draugrs que são erguidos durante o turno dos Draugrs (aquele que os Mascotes têm depois do turno de seus mestres) não agem durante essa ativação. **NOTA:** Um Necromante pode Erguer todos os quatro Draugrs, embora só possa sustentar dois deles durante seu turno.
+  - id: range-x
+    keyword: ALCANCE X
+    description: |
+      Alcance é contado usando X ÁREAS de distância.
+  - id: rangers-mark
+    keyword: MARCA DO PATRULHEIRO
+    description: |
+      Quando um personagem é Marcado, ele recebe um marcador de MARCA DO PATRULHEIRO. Todos os Ataques de Arma e Ataques Mágicos feitos pelo Patrulheiro contra um personagem que ele marcou causam +1 DANO. Como mencionado anteriormente, esse dano é dobrado se o personagem obtiver um Acerto Crítico normalmente.
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/ranger_mark.png
+  - id: reactions
+    keyword: REAÇÕES
+    description: |
+      Reações (<img src="/icons/reactions.svg" class="inline-icon" alt="Reactions">) podem ser usadas sempre que qualquer Herói for Ameaçado — ou seja, quando um dano prevenível estiver prestes a ser causado a ele. Todo dano é considerado prevenível a menos que descrito como “não prevenível” (como no caso das Condições). Cada Herói pode usar uma Reação por Ameaça. Isso significa que, se dois Heróis forem Ameaçados ao mesmo tempo, um Herói pode usar uma Reação para cada um deles.
+  - id: recall-ac
+    keyword: RECUPERAR CA
+    description: |
+      Devolva à sua Reserva o número indicado de Cubos de Ação GASTOS (aqueles alocados em Habilidades) ou DESCARTADOS (aqueles na Caixa de Cubos Gastos). Um efeito de RECUPERAR não é o mesmo que tomar uma Ação de Recuperação.
+  - id: recall-x
+    keyword: RECUPERAR X
+    description: |
+      Você recupera até X Cubos de Ação Gastos ou Usados do seu painel para sua caixa de Cubos de Ação Disponíveis.
+  - id: reckoner
+    keyword: JULGADOR
+    description: |
+      Um Monstro com Julgador tem como Alvo Principal o Herói Mais Corrompido (aquele com mais Cubos de Maldição no momento).
+  - id: redirect
+    keyword: REDIRECIONAR
+    description: |
+      Quando um efeito instrui você a Redirecionar um ataque para você ou outro Personagem, esse Personagem se torna o alvo daquele ataque. Se o Personagem em questão já estiver sendo alvo daquele ataque (como poderia estar em Multialvo, Talhar ou Golpe, por exemplo), ele sofre duas vezes, resolvendo um ataque de cada vez. Redirecionar um ataque não gera uma ameaça adicional e, portanto, não permite uma Reação extra.
+  - id: redundant
+    keyword: REDUNDANTE
+    description: |
+      Um efeito redundante significa que um personagem só pode ter um marcador daquele efeito específico. Se um personagem ganhasse um segundo marcador de um efeito redundante, apenas ignore-o.
+  - id: regain-x-health
+    keyword: RECUPERAR X DE VIDA
+    description: |
+      O alvo recupera X de Vida. Um Personagem nunca pode ganhar mais Vida do que seu valor máximo. Qualquer excesso de Vida é perdido. Como este efeito não está vinculado à Palavra-Chave CURAR, seu Herói não recebe nenhum bônus de habilidades “CURAR +X”.
+  - id: regain-your-breath
+    keyword: RECUPERAR O FÔLEGO
+    description: |
+      Recupere-se de estar NOCAUTEADO.
+  - id: regeneration-x
+    keyword: REGENERAÇÃO X
+    description: |
+      O Personagem recupera X de Vida que não pode exceder a Vida máxima.
+  - id: reinforce
+    keyword: REFORÇAR
+    description: |
+      Reforçar é um aprimoramento que um efeito de CURAR pode ter. Sempre que isso ocorrer, quaisquer Pontos de Vida que excedam o máximo do Personagem alvo são convertidos em marcadores de ESCUDO (ainda respeitando o limite de empilhamento de 4) em vez de serem desperdiçados.
+  - id: relearn
+    keyword: REAPRENDER
+    description: |
+      Reaprender é um termo associado ao progresso do personagem. Pode se referir a uma Habilidade de Herói ou Função de Masmorra Nível 1 ou 2, um Aprimoramento de Habilidade ou à escolha de uma Função de Masmorra, por exemplo. Reaprender algo significa substituir uma escolha que você fez em relação àquele elemento. Assim, Reaprender uma Função de Masmorra é um processo simples de “trocar” as cartas em sua Função de Masmorra *(mantendo suas progressões escolhidas como normal)* enquanto Reaprender uma Habilidade seria esquecer *(remover a progressão de)* uma Habilidade que você tem e escolher outra em seu lugar *(lembre-se, ao Reaprender uma Habilidade de Herói ou Função de Masmorra, você precisará ajustar seus Cubos de Ação apropriadamente e pode ser forçado a Reaprender também a Habilidade de Nível 2 associada àquela Árvore de Habilidades).*
+  - id: relentless
+    keyword: IMPLACÁVEL
+    description: |
+      Um Monstro com Implacável tem como Alvo Principal o Herói Mais Cansado (aquele com menos Cubos de Ação disponíveis no momento).
+  - id: reroll
+    keyword: REROLAR
+    description: |
+      Quando uma Habilidade tem REROLAR, significa que você recebe uma rerrolagem grátis do d20 para um Ataque de Arma realizado por aquela Habilidade que você pode escolher usar quando erra.
+  - id: resolved
+    keyword: RESOLVIDA
+    description: |
+      “Resolvida” é o termo usado para denotar o fim de alguma situação de jogo. Assim, quando é mencionado com um efeito, significa logo após aquele efeito ser aplicado. Por exemplo, analise a seguinte afirmação sobre uma regra básica referente ao dano Colateral: *“Efeitos colaterais são aplicados após o dano ser resolvido.”* Assim, se um personagem Reage com uma Habilidade de Cambalhota contra o ataque de um Cavaleiro das Sombras, ele se move antes de ser Derrubado, já que a Habilidade de Cambalhota (e seu Saltar 2) deve ser totalmente resolvida antes que qualquer dano Colateral se aplique (se for aplicado). Este termo também pode ser encontrado referindo-se a uma Interação ou Resolução. Quando esse for o caso, você deve saber a qual desses dois elementos está conectado. Essa é a chave para entender seu significado. *“Até que a Interação... seja resolvida”* significa que a Interação deve ser feita por completo; ou seja, até que o marcador de Interação seja removido do tabuleiro. Isso pode ser porque ela ficou sem cargas ou um efeito estipulou que ela deve ser removida antes disso. A frase *“...esta Resolução é resolvida”* só se aplica à Resolução que você está lendo naquele momento. Mesmo que uma Resolução seja abruptamente resolvida por seu próprio comando, ainda removerá 1 carga do marcador de Interação (a menos que seja uma Interação Recorrente ou o próprio efeito especifique de outra forma, é claro).
+  - id: ressurrect
+    keyword: RESSUSCITAR
+    description: |
+      Gere todos os Monstros listados, colocando suas miniaturas no tabuleiro, gerando um de cada vez na ordem das Runas mostrada na carta, repetindo o processo até que todos os Monstros sejam gerados.
+  - id: restrain
+    keyword: IMOBILIZAR
+    description: |
+      Personagens com a habilidade de Imobilizar estão armados com contenções naturais ou artificiais e podem usar essa habilidade para sempre manter seus oponentes dentro do alcance. Quando um Personagem é Imobilizado por um inimigo, ele recebe um marcador de Imobilizar e não pode deixar o espaço que ocupa enquanto o segurar. Um Personagem pode descartar seu marcador de Imobilizar quando não houver mais inimigos com a habilidade de Imobilizá-lo dentro do Alcance 1. Imobilizar é uma Condição redundante. **NOTA:** Personagens que estão Imobilizados podem deixar seu espaço por meio de um efeito de Trocar. Quando esse for o caso, o Objeto que troca com o Personagem Imobilizado pega seu marcador de Imobilizar. Se este alvo não for um Personagem, o efeito de Imobilizar termina.
+  - id: retaliate-x
+    keyword: RETALIAR X
+    description: |
+      Inflija X de Dano ao atacante dentro do AC ou qualquer alcance de outra forma. O conjurador deve ser um dos alvos.
+  - id: robust-trait
+    keyword: ROBUSTO (TRAÇO)
+    description: |
+      Você está tão embriagado que até se esquece de sentir dor. Nenhum dano pode reduzir sua Vida abaixo de 1. Isso inclui dano não prevenível, como o da Escuridão e o de Condições Persistentes.
+  - id: roll-x
+    keyword: ROLAR X
+    description: |
+      Dispara um benefício para a rolagem de ataque em rolagem natural. Modificadores +X ACERTO não disparam isso.
+  - id: round
+    keyword: RODADA
+    description: |
+      Rodada é um termo usado para denotar a janela de tempo desde a primeira carta a receber um turno na Trilha de Iniciativa até a última. Assim, podemos dizer que o Herói que joga com a Função de Masmorra de Defensor sempre será o primeiro Personagem a agir em uma Rodada, enquanto a carta de Runa sempre será a última. Todos os efeitos que são medidos por meio de uma rodada (ou seja, “...durante esta rodada”) terminam assim que o turno da carta de Runa naquela rodada é resolvido.
+  - id: self
+    keyword: EM SI
+    description: |
+      Habilidades com a Palavra-Chave EM SI só podem mirar no personagem conjurador. Por exemplo: "EM SI, PREVENIR 3" significa que o personagem pode prevenir 3 de dano apenas em si mesmo.
+  - id: shadow-aura
+    keyword: AURA DA ESCURIDÃO
+    description: |
+      Um pequeno tile de Escuridão é colocado sob o Alvo. Ele aciona seu efeito.
+  - id: shield-x
+    keyword: ESCUDO X
+    description: |
+      O alvo ganha X marcadores de ESCUDO. Cada marcador de ESCUDO pode ser usado para absorver 1 ponto de dano recebido contra o personagem. Você deve usar todos os seus marcadores de ESCUDO antes de perder qualquer Vida ou usar um efeito de PREVENIR—você não pode optar por receber o dano e manter seus marcadores de ESCUDO ou PREVENIR o dano com outra Habilidade para economizá-los. Marcadores de ESCUDO são um recurso EMPILHÁVEL.
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/shield.png
+  - id: shockwave
+    keyword: ONDA DE CHOQUE
+    description: |
+      Este Monstro inflige 4 de dano a todos os Campeões adjacentes a ele no início e no fim de seu movimento.
+  - id: shove
+    keyword: EMPURRAR PARA O LADO
+    description: |
+      Quando dois personagens ocupariam o mesmo espaço e um deles tem prioridade sobre o outro, dizemos que o primeiro empurra o segundo para o lado. Quando um personagem é empurrado para o lado, ele é movido para uma casa adjacente à área (quadrado azul) que ocupava anteriormente. O Líder do Grupo escolhe para onde um Monstro seria empurrado, enquanto um Herói empurrado pode escolher sua nova posição. Personagens sofrem os efeitos de pisar em terreno prejudicial quando são empurrados para eles (se ainda não os sofreram neste turno).
+  - id: silence
+    keyword: SILÊNCIO
+    description: |
+      (Conta como FADIGA) GASTAR todos os CA de Agilidade e Sabedoria.
+  - id: skull-cracker
+    keyword: ESMAGA-CRÂNIO
+    description: |
+      "Monstros com esta habilidade são terrivelmente perigosos. Ataques feitos por criaturas com esta habilidade automaticamente perfurarão qualquer valor de Robustez. Portanto, cuidado: o ataque de tais criaturas é letal contra Aliados como Companheiros, Seguidores, Mascotes e assim por diante (você ainda pode usar Prevenções de suas Reações ou Interrupções para tentar reduzir o dano a 0 e evitar que um Seguidor aliado seja derrotado)."
+  - id: slaughter
+    keyword: MASSACRE
+    description: |
+      Um Monstro com Massacre tem como Alvo Principal marcadores de NPC (não Companheiros).
+  - id: slayer
+    keyword: MATADOR
+    description: |
+      Um Monstro com esta habilidade perseguirá marcadores de NPC Ferido, Coortes e Seguidores como seu Alvo Principal, nesta ordem de preferência. Se houver dois ou mais dentro do alcance, o Líder do Grupo escolhe qual deles será o alvo deste Monstro neste turno. Se nenhum desses NPCs estiver no tabuleiro ou ao alcance, esses Monstros mudam seu Alvo Principal para o Herói Mais Forte.
+  - id: slow
+    keyword: LENTO
+    description: |
+      O Alvo recebe um marcador de LENTO. Diferente de outras Condições, LENTO não tem efeito no início do próximo turno daquele personagem, ele persiste até ser removido. Na próxima vez que o personagem afetado receber um efeito de Mover, ele perde 2 pontos de movimento desse efeito e remove seu marcador de LENTO de seu painel. LENTO é uma Condição redundante.
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/slow.png
+  - id: solid-objects
+    keyword: OBJETOS SÓLIDOS
+    description: |
+      Personagens, Baús, Interações, Pilhas de Runas, NPCs e outros especificados como tal durante uma preparação.
+  - id: soul-shard
+    keyword: FRAGMENTO DE ALMA
+    description: |
+      Ao confinar um fragmento de energia vital do espírito de uma criatura em si, esses cristais podem ser usados para fortalecer os Heróis. Como uma Ação Menor, um Herói pode descartar um Fragmento de Alma para dar Dano Dobrado ao próximo Ataque de Arma ou Ataque Mágico que fizer neste turno. Note que este efeito dura apenas até o final deste turno ou quando você fizer seu próximo Ataque de Arma ou Ataque Mágico (mesmo que erre), o que ocorrer primeiro. Se um efeito permitir que você faça dois ou mais Ataques de Arma separados como parte da mesma Ação, este efeito só é aplicado ao primeiro deles *(Talhar é um único golpe que afeta dois ou mais alvos, então este bônus se aplica a todos eles)*. Fragmentos de Alma são marcadores de Recurso redundantes que podem ser trocados entre Heróis como se fossem Itens Consumíveis.
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/soul_chard.png
+  - id: special-mechanic-tokens
+    keyword: MARCADORES DE MECÂNICA ESPECIAL
+    description: |
+      Estes elementos do tabuleiro são usados como marcos visuais para a função de qualquer Mecânica Especial estabelecida para uma Aventura. Marcadores de Mecânica Especial são Objetos de Solo Imóveis.
+  - id: spell-attack
+    keyword: ATAQUE MÁGICO
+    description: |
+      Causa dano diretamente ao alvo, não exigindo Teste de Precisão. <img src="/icons/1-spell-dmg.svg" class="inline-icon" alt="Spell Damage"> não são <img src="/icons/2-melee-dmg.svg" class="inline-icon" alt="Melee Damage"> e, portanto, não levam em conta a Precisão ou o Poder da Arma. No entanto, ainda podem receber bônus de Equipamentos, Habilidades de Herói e Aptidões de Classe, por exemplo.
+  - id: spend
+    keyword: GASTAR
+    description: |
+      Um cubo é considerado GASTO quando um Herói o aloca em um de seus espaços de Habilidade ou de Reação, ocupando aquele espaço com o cubo.
+  - id: spent
+    keyword: GASTO
+    description: |
+      Um Cubo de Ação é considerado gasto quando é alocado em um espaço de Habilidade. Cubos de Maldição e Cubos de Trauma não são considerados Cubos de Ação mesmo quando são gastos como Cubos de Ação. Eles são tratados como ferimentos normais uma vez que se tornam alocados em um espaço.
+  - id: split
+    keyword: DIVIDIR
+    description: |
+      Os pontos deste efeito podem ser divididos entre os alvos da maneira que for mais conveniente para o Herói conjurador. O Herói não pode escolher atribuir “0” pontos do efeito a um alvo.
+  - id: spread
+    keyword: DISPERSAR
+    description: |
+      Alguns ataques se espalham ao redor da vítima. Sempre que um Herói é acertado por DISPERSAR, ele reflete a mesma quantidade de dano que sofreu (dano sofrido é o dano que foi recebido e não foi mitigado ou PREVENIDO) em cada outro Herói que estiver Adjacente a ele. Este dano refletido é causado como dano não prevenível. Por exemplo, Vorn recebeu 6 de dano com DISPERSAR. Depois de mitigar 2 de dano com seus 2 marcadores de ESCUDO e PREVENIR 2 de dano com uma Habilidade, no final, ele sofreu 2 de dano. Então, cada outro Herói que estiver Adjacente a ele recebe 2 de dano não prevenível.
+  - id: square
+    keyword: CASA
+    description: |
+      Refere-se a um quadrado branco no tile do mapa. 
+  - id: STACKABLE
+    keyword: EMPILHÁVEL
+    description: |
+      A propriedade EMPILHÁVEL significa que um personagem pode manter até 4 cópias de um mesmo marcador em seus painéis/cartas. Um marcador de dois lados que exibe as faces 1 e 2 deve sempre ser considerado como se fosse o número de marcadores individuais indicado. Se um personagem receberia um quinto marcador de um efeito EMPILHÁVEL, apenas ignore-o. **Exemplo:** *2 marcadores de Foco 2 e 4 marcadores de Foco 1 são considerados Foco 4 de qualquer forma.*
+  - id: stalker-(trait)
+    keyword: ESPREITADOR (TRAÇO)
+    description: |
+      Alguns assassinos se especializam em usar a furtividade a seu favor. Enquanto a Habilidade Espreitador não estiver bloqueada, sempre que a Furtividade do Matador desaparecer *(ou seja, é removida por conta própria no início do turno de seu Herói)*, o Matador permanece Oculto até o fim do turno do Herói atual ou até que ele tente surpreender outro Personagem. **Exemplo:** *Nyx recebeu Furtividade por meio da Habilidade **Golpe Traiçoeiro** na rodada anterior. No início de seu turno, nesta nova rodada, sua Furtividade desapareceu, mas ela ainda permanecerá oculta até que tente surpreender outro Personagem (o que poderia levá-la a causar Dano Dobrado) ou termine seu turno atual (assim, ela precisaria conjurar outro efeito de Furtividade se quisesse continuar em Furtividade para escapar dos ataques dos Monstros).*
+  - id: status
+    keyword: ESTADO
+    description: |
+      Estado é uma recompensa relacionada a uma escolha que um personagem fez durante a história. Alguns Estados podem dar habilidades especiais como se fossem uma espécie de bênção, enquanto outros são apenas relacionados à história. De qualquer forma, um personagem pode ter qualquer número de Estados anotados em seu Registro de Campanha e todos os Estados são apagados durante a próxima Fase de Acampamento.
+  - id: stealth
+    keyword: FURTIVIDADE
+    description: |
+      FURTIVIDADE é uma Condição Benéfica. Quando um Personagem recebe FURTIVIDADE, ele pega o marcador apropriado e o coloca em seu painel. Enquanto o tiver, Monstros que não sejam Imunes a FURTIVIDADE não alvejam aquele Herói, mas também não ficam sujeitos ao Engajamento em Combate causado por ele. No início do próximo turno daquele Personagem, ele descarta o marcador de FURTIVIDADE, encerrando a Condição. Alternativamente, se aquele Herói fizer um <img src="/icons/2-melee-dmg.svg" class="inline-icon" alt="Melee Damage"> enquanto ainda estiver com o marcador, ele o descarta antecipadamente — mas se aquele <img src="/icons/2-melee-dmg.svg" class="inline-icon" alt="Melee Damage"> acertar, ele se torna um Acerto Crítico. Monstros Imunes a FURTIVIDADE também são imunes a este “Ataque Oportunista”.
+  - id: strike-x
+    keyword: GOLPE X
+    description: |
+      Mira em todos os personagens em X ÁREAS dentro do Alcance. Corpo a corpo deve ser em ÁREAS adjacentes à própria CASA.
+  - id: strongest-hero
+    keyword: HERÓI MAIS FORTE
+    description: |
+      O Herói com a maior Vida no momento. Os Monstros frequentemente miram no Herói Mais Forte. Se dois Heróis estiverem empatados com a maior Vida, o Mais Forte entre eles será aquele que ocupa o Espaço de Iniciativa mais rápido.
+  - id: stun
+    keyword: ATORDOAR
+    description: |
+      ATORDOAR é uma Condição Debilitante que funciona de forma diferente para Monstros e Heróis. Quando um Personagem sofre ATORDOAR, ele pega o marcador apropriado e o coloca em seu painel. No início de seu próximo turno, ele descarta o marcador de ATORDOAR. Se o Personagem for um Monstro, ele não ataca naquele turno (ainda pode se mover normalmente). Se o Personagem for um Herói, ele pode tomar 1 Ação com Cubo a menos naquele turno. ATORDOAR é uma Condição Redundante (apenas 1 instância por vez).
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/stun.png
+  - id: sturdiness
+    keyword: ROBUSTEZ
+    description: |
+      Dano que exceda este número derrota o Personagem.
+  - id: suffer
+    keyword: SOFRER
+    description: |
+      Sofrer não é propriamente uma Palavra-Chave, porém, é um termo que vale esclarecer. Sofrer é usado para definir algo que “acerta” um Personagem depois que ele tentou se proteger contra isso. Assim, “sofrer dano” significa perder Vida devido a dano depois que você tentou (se pudesse, naturalmente) mitigá-lo através de Prevenir, marcadores de Escudo e assim por diante.
+  - id: surge
+    keyword: SURTO
+    description: |
+      Quando você Ataca, se a rolagem do D20 resultar em um Natural 16 ou mais, o efeito descrito é acionado. Aplique este efeito antes de o Dano ser causado ao alvo. “Natural” se refere ao valor rolado no D20, ignorando quaisquer bônus ou penalidades.
+  - id: swap
+    keyword: TROCAR
+    description: |
+      Quando duas miniaturas TROCAM, elas trocam suas posições no tabuleiro. Miniaturas trocadas dessa forma “entram” em suas novas posições.
+  - id: swarm
+    keyword: ENXAME
+    description: |
+      Monstros de Enxame são criaturas minúsculas que, unidas, formam um único ser e, portanto, não têm pontos vitais em seu corpo. Tais criaturas sofrem apenas metade do dano (arredondado para cima, após aplicadas as reduções de Prevenir) de todos os Ataques de Arma que os acertarem. **Exemplo:** *Se Lorelai tiver 2 marcadores de Intimidar quando ataca um Monstro que tem Enxame e 1 marcador de Escudo usando um ataque de 6 de dano, aquele Monstro sofreria apenas 2 pontos de dano no final (6 - 2 - 1 = 3; 3 ÷ 2 = 1,5, que é arredondado para 2).*
+  - id: take
+    keyword: RECEBER
+    description: |
+      “Receber” é usado para descrever algo que é dado a um Personagem. Sempre que isso for dano, ele tem a oportunidade de mitigá-lo por meio de marcadores de Escudo ou efeitos de Prevenir (a menos, é claro, que o dano seja não prevenível). Se for uma Condição (como Sangramento) ou um Efeito (como Telecinese), aquele Personagem não pode usar Reações ou Interrupções para evitá-lo, mas, se for Imune aos referidos efeitos, ele simplesmente não os recebe. Receber um Cubo de Maldição, por outro lado, é diferente de sofrer Maldição e, portanto, este efeito não pode ser evitado mesmo que o Personagem seja Imune a Maldição.
+  - id: telekinesis-x
+    keyword: TELECINESE X
+    description: |
+      Mova qualquer objeto de tamanho pequeno (incluindo pequenos tiles de Escuridão) ou OBJETOS SÓLIDOS (exceto Interações) até X CASAS. O Alvo é afetado por terreno prejudicial ou Escuridão onde pousa, incluindo DANO DE QUEDA.
+  - id: threat
+    keyword: AMEAÇA
+    description: |
+      Ameaça é o termo usado para definir o momento em que um Herói pode ter seus pontos de Vida reduzidos por algum ataque ou efeito, mas é capaz de se defender e tentar impedir que isso aconteça. Assim, Ameaça essencialmente define quando um Herói pode usar uma Reação no jogo. Como regra, os Heróis podem usar tais Habilidades ou Aptidões sempre que um Herói (ele mesmo ou um aliado) é ameaçado, ou seja, quando recebe dano prevenível (dano não prevenível nunca gera Ameaça). Note que Ameaça é apenas um termo, ele não muda nenhuma regra. Portanto, Reações com “EM SI” só podem ser usadas se o Personagem conjurador também estiver sendo ameaçado e assim por diante, como descrito na página 14 do Livro de Regras da Caixa Base.
+  - id: throw-(bookshelf)
+    keyword: ARREMESSAR (ESTANTE DE LIVROS)
+    description: |
+      "Estantes de Livros são pesadas demais para serem arremessadas contra um Personagem com uma Ação Menor. Em vez disso, elas são simplesmente derrubadas, afetando um Personagem adjacente a ela (escolhido pelo Herói que usou a Ação Menor Arremessar Mobília). TELECINESE, por outro lado, pode arremessar uma estante de livros normalmente. - Independente da forma como for arremessada, uma estante de livros causa 2 DANO e inflige ATORDOAR a seu alvo (Não esqueça: Mobília arremessada é sempre quebrada e removida do tabuleiro.)"
+  - id: throw-(chest)
+    keyword: ARREMESSAR (BAÚ)
+    description: |
+      "Quando arremessado contra um Personagem, um Baú causa 2 DANO e você deve rolar o Dado de Armadilha: some o resultado a este dano como efeito colateral. *(Não esqueça, Mobília arremessada é quebrada e removida do tabuleiro.)*"
+  - id: throw-(piles-of-crates)
+    keyword: ARREMESSAR (PILHA DE CAIXOTES)
+    description: |
+      Quando arremessada, a Pilha de Caixotes inflige FRÁGIL a seu alvo se ele for um Personagem Pequeno. - Corpos de Monstros Grandes são tão poderosos que os caixotes nem os incomodam. (Não esqueça, Mobília arremessada é quebrada e removida do tabuleiro.)
+  - id: throw-(stack-of-barrels)
+    keyword: ARREMESSAR (PILHA DE BARRIS)
+    description: |
+      Quando arremessado contra um Personagem, um barril causa 2 DANO e inflige DERRUBAR ao seu alvo se ele for um Personagem Pequeno. Corpos de Monstros Grandes são tão poderosos que barris nem os incomodam. - No entanto, se um Herói estava escondido dentro do barril, o arremesso causa +2 DANO e pode até mirar em Monstros Grandes e infligir DERRUBAR a eles (superando sua imunidade graças ao peso extra). - Reposicione o Herói que estava no barril em uma casa à sua escolha que seja adjacente ao alvo contra o qual o barril foi arremessado. *(Não esqueça, Mobília arremessada é quebrada e removida do tabuleiro).*
+  - id: throw-(stone-fountains)
+    keyword: ARREMESSAR (FONTE DE PEDRA)
+    description: |
+      Fontes de Pedra estão fixadas ao chão e, portanto, não podem ser arremessadas contra outros Personagens de forma alguma *(mas ainda podem ser destruídas por Monstros Grandes que terminam seu movimento pisando nelas).*
+  - id: throw-(stone-pillar)
+    keyword: ARREMESSAR (PILAR DE PEDRA)
+    description: |
+      Pilares de Pedra estão fixados ao chão e ao teto e, portanto, não podem ser arremessados contra outros personagens de forma alguma. No entanto, é precisamente por serem tão firmes que o oposto se torna verdadeiro: - Quando um Personagem é arremessado contra um pilar de pedra (por efeitos como TELECINESE ou EMPURRAR), ele sofre 4 de dano não prevenível e é reposicionado em uma casa adjacente ao pilar escolhida pelo Personagem que o arremessou. O pilar não é removido do tabuleiro.
+  - id: trample-x
+    keyword: PISOTEAR X
+    description: |
+      PISOTEAR é um aprimoramento do efeito MOVER. Movimentos usando PISOTEAR podem atravessar (mas não parar em) casas ocupadas por Inimigos. Além disso, quando um Personagem PISOTEANDO atravessa um Inimigo dessa forma, ele causa o dano listado àquele Personagem. Cada Inimigo só pode sofrer dano de PISOTEAR uma vez por movimento.
+  - id: trap
+    keyword: ARMADILHA
+    description: |
+      Coloque um marcador de Armadilha no centro de uma área adjacente à sua área (quadrado azul). Na primeira vez que um inimigo se ativar dentro daquela área ou se mover para dentro daquela área, a Armadilha é disparada. Todos os inimigos dentro daquela área são afetados pela Armadilha, então remova o marcador de Armadilha. Só pode haver 1 marcador de Armadilha em uma área por vez.
+  - id: trauma-cube-(tc)
+    keyword: CUBO DE TRAUMA (CT)
+    description: |
+      Cubos roxos que são alocados em habilidades de Herói ou de Funções de Masmorra e bloqueiam seu uso. O Herói é morto ao receber um 2º CUBO DE TRAUMA e encerra a aventura.
+  - id: trick-or-treat
+    keyword: DOCES OU TRAVESSURAS
+    description: |
+      O controlador de Tharmagar escolhe ALCANCE 1, CURAR 2 ou ALCANCE 1, (SANGRAMENTO 2 ou QUEIMADURA 2 ou VENENO 2).
+  - id: turn
+    keyword: TURNO
+    description: |
+      Turno é o termo usado para designar a janela de tempo em que um Personagem ou uma carta na Trilha de Iniciativa pode agir. Embora um tipo de Monstro tenha apenas uma carta na Trilha de Iniciativa para representar todas as unidades daquele tipo, o turno de cada Monstro é tomado individualmente. Portanto, o turno de um Cavaleiro das Sombras com uma base de encaixe rosa é diferente do turno de um Cavaleiro das Sombras com base de encaixe verde. Esta distinção é importante, porque efeitos que podem ser usados uma vez por turno podem ser usados uma vez durante o turno de cada um desses Cavaleiros das Sombras, por exemplo.
+  - id: two-handed
+    keyword: DUAS MÃOS
+    description: |
+      Armas que exigem ambas as Mãos para serem empunhadas têm esta propriedade. Heróis não podem equipar Ferramentas de Mão Secundária enquanto empunham estas Armas. Além disso, sempre que receberem um efeito que os instrua a realizar um <img src="/icons/2-melee-dmg.svg" class="inline-icon" alt="Melee Damage">, aqueles Heróis podem realizar apenas um <img src="/icons/2-melee-dmg.svg" class="inline-icon" alt="Melee Damage"> daquele efeito (por exemplo, Golpe Duplo). Heróis empunhando Armas de Duas Mãos ainda podem realizar mais de um <img src="/icons/2-melee-dmg.svg" class="inline-icon" alt="Melee Damage"> por turno, desde que sejam de Ações separadas. Sempre que um Herói equipa uma Arma de Duas Mãos, ele deve guardar na mochila qualquer Ferramenta de Mão Secundária que estivesse segurando. Se a mochila estiver cheia, ele deve escolher 1 item para descartar sem aplicar seus efeitos.
+  - id: unavailable
+    keyword: INDISPONÍVEL
+    description: |
+      Este é um termo de jogo geralmente associado a Interações. Quando um efeito afirma que uma Resolução se torna indisponível, significa que os Heróis não podem mais escolher aquela Resolução. Sempre que um Herói escolhe uma Resolução de uma Interação Carregada, por exemplo, ela se torna indisponível e não pode ser escolhida novamente durante esta Aventura.
+  - id: unique
+    keyword: ÚNICO
+    description: |
+      Este mascote só pode ser invocado por uma habilidade específica. Caso contrário, uma vez invocado, habilidades de ativação de mascote podem ser usadas.
+  - id: unlife
+    keyword: NÃO VIDA
+    description: |
+      Mascotes com este traço têm uma vida deitada, precisando de poder necrótico para permanecer de pé. No início do turno de seu mestre, eles serão dispensados. Nesse momento, o Necromante pode escolher receber um Cubo de Maldição para estender a Não Vida de tal Mascote por um turno—Isso é chamado de “Contaminação”. Ele pode escolher para cada Mascote com este traço se faz ou não isso, pagando o custo de Contaminação individualmente para cada um.
+  - id: versatile
+    keyword: VERSÁTIL
+    description: |
+      Equipamentos com esta propriedade podem ser empunhados de duas maneiras diferentes. Quando o Herói equipa uma dessas cartas, ele escolhe um de seus lados — Frente ou Verso — para usar. A partir de então, como uma Ação Menor em seu turno, ele pode escolher virar a carta para o outro lado.
+  - id: vicious
+    keyword: VIL
+    description: |
+      O dano causado pelo ataque deste Monstro é não prevenível.
+  - id: volatile
+    keyword: VOLÁTIL
+    description: |
+      Monstros com esta habilidade têm um talento para acelerar reações em cadeia. Quando este Monstro ativa, antes de se Mover e Atacar, acione todas as Condições de Dano Persistente que afetam cada Herói dentro do Alcance 1 daquele Monstro.
+  - id: voodoo
+    keyword: VUDU
+    description: |
+      Quando um Monstro tem esta habilidade, ele é capaz de remover suas Condições EMPILHÁVEIS infligindo-as de volta contra os Heróis. Assim, no início do turno desses Monstros, quando forem afetados por Condições EMPILHÁVEIS *(Queimadura, Sangramento e Intimidar são exemplos de Condições EMPILHÁVEIS)*, se algum de seus inimigos (Herói, Mascote, Companheiro etc.) estiver dentro do Alcance 1 daquele Monstro, em vez de sofrer tais efeitos, mova-os para o inimigo mais forte entre eles. Se o Monstro não puder redirecionar tais marcadores, só então ele sofre tais efeitos.
+  - id: war-cry
+    keyword: GRITO DE GUERRA
+    description: |
+      Grito de Guerra é uma habilidade disparada que alguns Monstros possuem. Quando ativada, cada outro Monstro dentro do Alcance 1 deste Monstro enfurece e ganha um marcador de +1 DANO permanentemente (coloque este marcador em seu painel de Status de Monstro).
+  - id: warden-(trait)
+    keyword: GUARDIÃO (TRAÇO)
+    description: |
+      Personagens que têm o traço Guardião podem usar Interrupções e Reações com a Palavra-Chave “EM SI” em outros Personagens desde que estejam adjacentes a eles. Além disso, Guardiões podem usar tais Habilidades quando Personagens adjacentes a eles são atacados ou ameaçados (se a Habilidade que estiverem usando for uma Interrupção ou uma Reação, respectivamente) em vez de usá-las apenas quando eles próprios são atacados ou ameaçados.
+  - id: warlock-(trait)
+    keyword: BRUXO (TRAÇO)
+    description: |
+      Barganhando com a Escuridão, Bruxos flertam com a corrupção em troca de poder. Enquanto a Habilidade Pacto de Outro Mundo não estiver bloqueada, eles recebem seus Cubos de Maldição como se fossem Cubos de Ação e, quando os gastam, esses são tratados como Cubos Curinga. Uma vez gastos, esses cubos se tornam Cubos de Maldição convencionais novamente e só são removidos por efeitos de Purificar.
+  - id: weakest-hero
+    keyword: HERÓI MAIS FRACO
+    description: |
+      O Herói com a menor Vida no momento é o Herói Mais Fraco. Se dois Heróis estiverem empatados com a menor Vida, o mais fraco entre eles será aquele que ocupa o espaço de Iniciativa mais lento.
+  - id: weapon-attack
+    keyword: ATAQUE DE ARMA
+    description: |
+      O Herói deve fazer um Teste de Precisão rolando um D20 e somando seus bônus de Para Acertar. Some os bônus concedidos pela instrução <img src="/icons/2-melee-dmg.svg" class="inline-icon" alt="Melee Damage"> a quaisquer bônus passivos de Equipamentos, Habilidades de Herói e Aptidões de Classe que ele tenha. Se a rolagem igualar ou exceder o valor de Precisão da Arma (losango azul), o ataque acerta e causa dano, incluindo quaisquer bônus de dano aplicáveis. Se a rolagem for um 20 natural, é um Acerto Crítico — dobre o dano do ataque. Se for um 1 natural, é um Erro Crítico — o ataque falha independentemente dos bônus. Heróis que não estejam empunhando uma Arma não podem fazer Ataques de Arma. Se um efeito instruir você a fazer dois ou mais Ataques, resolva-os um de cada vez, escolhendo cada alvo no momento em que fizer aquele Ataque específico.
+  - id: wild-copy
+    keyword: CÓPIA CURINGA
+    description: |
+      Um efeito que faz Cópia Curinga de uma Habilidade aplica os mesmos efeitos de uma Cópia, mas dobra todos os números escritos em sua forma numérica, como teria acontecido se aqueles efeitos tivessem sido conjurados gastando um Cubo Curinga.
+  - id: wild-cube
+    keyword: CUBO CURINGA
+    description: |
+      Considerado como sendo um CA de qualquer cor. Efeitos de Habilidade de Herói (não Funções de Masmorra ou Equipamento) são dobrados, incluindo condições.
+  - id: windwalker-trait
+    keyword: ANDARILHO DO VENTO (TRAÇO)
+    description: |
+      Seu corpo está acelerado e suas pernas inquietas. O primeiro efeito de MOVER que você receber a cada turno ganha um bônus de +3 e você também pode tomar uma Ação com Cubo adicional a cada turno.
+  - id: wounded
+    keyword: FERIDO
+    description: |
+      Ferido é um estado de saúde em que os Personagens podem estar. Personagens que têm metade ou menos (arredondado para baixo) de seus Pontos de Vida máximos são considerados Feridos. Algumas habilidades interagem com Personagens nessas condições.
+  - id: x
+    keyword: X
+    description: |
+      Qualquer variável 'X' em uma carta de Monstro ou Ataque significa o número de marcadores de Runa na Trilha de Iniciativa que corresponde à Runa daquele Ataque.
+  - id: x-dmg
+    keyword: +X ou -X DANO
+    description: |
+      O valor X é somado ou subtraído do Dano que seu Ataque causa. Acertos Críticos e DANO DOBRADO também dobram esse valor.
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/%2B1dmg.png
+  - id: x-hit
+    keyword: +X ou -X ACERTO
+    description: |
+      Faça um Ataque de Arma somando (ou subtraindo) o valor X à sua rolagem de dado. Afeta apenas a Precisão, não a obtenção de um Acerto Crítico.
+  - id: x-hp
+    keyword: +X PV
+    description: |
+      A Vida Máxima do Herói aumenta em +X pontos. Conforme explicado na página 7 do Livro de Regras de Era das Trevas, a Vida Máxima de um Herói, porém, nunca pode exceder 16. Se um Herói tiver dois ou mais efeitos que aumentem seus Pontos de Vida, você deve sempre somá-los, mas nunca ultrapassar o valor de 16 mostrado no painel do Herói. Toda Vida Máxima que exceder 16 é considerada desperdiçada.
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/%2B30health.png
+  - id: x-hp-(simple)
+    keyword: +X PV (SIMPLES)
+    description: |
+      Se você prefere não lidar com a granularidade da regra +X PV, pode escolher a versão simples e desconsiderar a segunda e a terceira NOTA. Assim, se você perder um efeito que confere +X PV, perderá Vida de forma correspondente. Porém, se você recuperar esses efeitos depois, não recuperará nenhuma Vida, mesmo que a soma dos efeitos +X PV que você tenha exceda 16 de Vida.
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/%2B30health.png
+  - id: x-movement
+    keyword: +X MOVIMENTO
+    description: |
+      Você recebe X pontos adicionais de movimento a cada efeito de Mover ganho.
+    icon: https://s3.us-east-2.amazonaws.com/assets.drunagor.app/CampaignTracker/Keywords/%2B1mov.png

--- a/tests/locales/language.spec.ts
+++ b/tests/locales/language.spec.ts
@@ -1,0 +1,111 @@
+/**
+ * Regressão de carregamento de idioma, ponta a ponta.
+ *
+ * Duas restrições moldam este arquivo:
+ *
+ * 1. A tela de configuração (/campaign-tracker/configuration) e /campaign-tracker/keyword
+ *    têm `beforeEnter: requireAuth` e redirecionam para o login. A única superfície
+ *    pública que passa por i18n é /shared-keywords.
+ *
+ * 2. Entrar em /shared-keywords por deep-link estoura — em TODOS os idiomas,
+ *    inclusive en_US. É um bug de boot pré-existente e sem relação com tradução:
+ *    src/main.ts:27 chama `registerPlugins(app, "prod")` sem `await` e monta o app
+ *    em seguida, então componentes podem rodar seu setup antes de
+ *    `loadLanguage()` registrar as mensagens. KeywordDataRepository.load lê
+ *    `i18n.messages.value[locale].keyword` e encontra undefined.
+ *    Por isso entramos pela raiz (que boota bem) e navegamos pelo router.
+ *
+ * O idioma é semeado no localStorage porque o bootstrap em src/plugins/index.ts lê
+ * `ConfigurationStore.enabledLanguage`, um useStorage("LanguageStore.enabled").
+ */
+import { test, expect, type Page } from "@playwright/test";
+
+const CHAVE_STORAGE = "LanguageStore.enabled";
+
+/** Título do card em KeywordView.vue — vem de `menu.keyword`. */
+const TITULO = {
+  en_US: "Keyword",
+  pt_BR: "Palavra-chave",
+  de_DE: "Schlüsselwörter",
+} as const;
+
+/** Label do keyword `heal-x`, presente em todos os idiomas traduzidos. */
+const HEAL = {
+  en_US: "HEAL X",
+  pt_BR: "CURAR X",
+  de_DE: "HEILEN X",
+} as const;
+
+async function abreCatalogo(page: Page, idioma: string | null) {
+  await page.addInitScript(
+    ([chave, valor]) => {
+      if (valor === null) window.localStorage.removeItem(chave);
+      else window.localStorage.setItem(chave, valor);
+    },
+    [CHAVE_STORAGE, idioma] as [string, string | null],
+  );
+
+  await page.goto("/");
+  // espera o bootstrap assíncrono registrar as mensagens antes de trocar de rota
+  await page.waitForLoadState("networkidle");
+
+  // não há link no app para /shared-keywords; navegamos pelo history, que é o que
+  // o vue-router escuta, para não recarregar a página e cair no bug de deep-link
+  await page.evaluate(() => {
+    window.history.pushState({}, "", "/shared-keywords");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  });
+}
+
+/** O catálogo tem 223 entradas; filtrar deixa a asserção estável. */
+async function buscaKeyword(page: Page, termo: string) {
+  const busca = page.locator("#keyword-search").locator("input").first();
+  await busca.waitFor({ state: "visible" });
+  await busca.fill(termo);
+}
+
+test("pt_BR: catálogo de keywords renderiza em português", async ({ page }) => {
+  await abreCatalogo(page, "pt_BR");
+
+  await expect(page.getByText(TITULO.pt_BR, { exact: true }).first()).toBeVisible();
+
+  // prova que o array pt_BR carregou e que o lookup por id funciona
+  await buscaKeyword(page, "CURAR");
+  await expect(page.getByText(HEAL.pt_BR, { exact: true }).first()).toBeVisible();
+});
+
+test("pt_BR: keyword novo do Underkeep está traduzido", async ({ page }) => {
+  await abreCatalogo(page, "pt_BR");
+
+  // DUAS MÃOS (two-handed) não existia na versão antiga do app
+  await buscaKeyword(page, "DUAS");
+  await expect(page.getByText("DUAS MÃOS", { exact: true }).first()).toBeVisible();
+});
+
+test("de_DE: idioma já em produção continua funcionando", async ({ page }) => {
+  await abreCatalogo(page, "de_DE");
+
+  await expect(page.getByText(TITULO.de_DE, { exact: true }).first()).toBeVisible();
+  await buscaKeyword(page, "HEILEN");
+  await expect(page.getByText(HEAL.de_DE, { exact: true }).first()).toBeVisible();
+});
+
+test("es_ES: locale ainda vazio cai para inglês sem quebrar", async ({ page }) => {
+  const erros: string[] = [];
+  page.on("pageerror", (e) => erros.push(e.message));
+
+  await abreCatalogo(page, "es_ES");
+
+  // es_ES tem os 4 arquivos como esboço `---`; exercita o fallback de src/language.ts
+  await expect(page.getByText(TITULO.en_US, { exact: true }).first()).toBeVisible();
+  await buscaKeyword(page, "HEAL");
+  await expect(page.getByText(HEAL.en_US, { exact: true }).first()).toBeVisible();
+
+  expect(erros, "o fallback de idioma não deve lançar").toEqual([]);
+});
+
+test("sem preferência salva: usa inglês", async ({ page }) => {
+  await abreCatalogo(page, null);
+
+  await expect(page.getByText(TITULO.en_US, { exact: true }).first()).toBeVisible();
+});

--- a/tests/locales/locale-integrity.spec.ts
+++ b/tests/locales/locale-integrity.spec.ts
@@ -1,0 +1,281 @@
+/**
+ * Integridade estática dos arquivos de tradução.
+ *
+ * Não usa a fixture `page`, então roda sem browser. É a rede de proteção principal
+ * para mudanças em src/locales: pega YAML quebrado, chave duplicada, colisão entre
+ * namespaces, id órfão e markup perdido antes de qualquer coisa chegar ao runtime.
+ */
+import { test, expect } from "@playwright/test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import * as yaml from "js-yaml";
+
+// o projeto é "type": "module", então não há __dirname
+const AQUI = path.dirname(fileURLToPath(import.meta.url));
+const RAIZ = path.resolve(AQUI, "../..");
+const LOCALES = path.join(RAIZ, "src/locales");
+const SRC = path.join(RAIZ, "src");
+
+/** Os 4 namespaces que src/language.ts importa e mescla. */
+const ARQUIVOS = ["app", "campaign", "items", "keywords"] as const;
+
+/** Ordem espelha src/language.ts:11-19. */
+const IDIOMAS = ["en_US", "de_DE", "fr_FR", "es_ES", "it_IT", "pl_PL", "pt_BR"] as const;
+
+/** Idiomas com tradução completa esperada. Os demais podem ter lacunas. */
+const COMPLETOS = ["en_US", "pt_BR"] as const;
+
+/**
+ * Lacuna PRÉ-EXISTENTE, não introduzida por este trabalho: de_DE, fr_FR e pl_PL
+ * foram copiados da versão antiga do app e nunca receberam o conteúdo novo.
+ * O número trava a regressão — se a defasagem aumentar, o teste quebra.
+ */
+const DEFASAGEM_MAXIMA: Record<string, number> = {
+  de_DE: 38,
+  fr_FR: 38,
+  pl_PL: 42,
+};
+
+type Dicionario = Record<string, unknown>;
+
+function caminho(idioma: string, arquivo: string): string {
+  return path.join(LOCALES, idioma, `${arquivo}.yaml`);
+}
+
+function carrega(idioma: string, arquivo: string): Dicionario | null {
+  const bruto = fs.readFileSync(caminho(idioma, arquivo), "utf8");
+  // js-yaml lança em chave duplicada, que é justamente o que queremos detectar.
+  return (yaml.load(bruto) as Dicionario | null) ?? null;
+}
+
+/** Locale ainda não traduzido: arquivo com apenas `---`, que o YAML resolve para null. */
+function ehEsboco(idioma: string, arquivo: string): boolean {
+  return carrega(idioma, arquivo) === null;
+}
+
+/** Achata em caminhos folha, indexando arrays por posição. */
+function achata(valor: unknown, prefixo = "", saida: Record<string, string> = {}) {
+  if (valor === null || valor === undefined) return saida;
+  if (Array.isArray(valor)) {
+    valor.forEach((item, i) => achata(item, `${prefixo}[${i}]`, saida));
+    return saida;
+  }
+  if (typeof valor === "object") {
+    for (const chave of Object.keys(valor as Dicionario)) {
+      const p = prefixo ? `${prefixo}.${chave}` : chave;
+      achata((valor as Dicionario)[chave], p, saida);
+    }
+    return saida;
+  }
+  saida[prefixo] = String(valor);
+  return saida;
+}
+
+/** Markup que precisa sobreviver à tradução intacto. */
+const MARKUP = /\{[^}]+\}|<br\s*\/?>|<\/?b>|@:[\w.-]+|<img[^>]*>/g;
+
+function marcas(texto: string): string {
+  return (texto.match(MARKUP) ?? []).sort().join("|");
+}
+
+// ---------------------------------------------------------------------------
+// Invariantes de TODOS os idiomas — protegem o que já está em produção.
+// ---------------------------------------------------------------------------
+
+for (const idioma of IDIOMAS) {
+  test(`${idioma}: todo yaml existe e faz parse (sem chave duplicada)`, () => {
+    for (const arquivo of ARQUIVOS) {
+      const alvo = caminho(idioma, arquivo);
+      expect(fs.existsSync(alvo), `${alvo} não existe`).toBe(true);
+      expect(() => carrega(idioma, arquivo), `${idioma}/${arquivo}.yaml não faz parse`).not.toThrow();
+    }
+  });
+
+  test(`${idioma}: namespaces de topo são disjuntos`, () => {
+    // src/language.ts mescla os 4 arquivos com spread raso; uma chave de topo
+    // repetida entre eles apagaria silenciosamente o namespace anterior.
+    const dono = new Map<string, string>();
+    for (const arquivo of ARQUIVOS) {
+      const dados = carrega(idioma, arquivo);
+      if (dados === null) continue;
+      for (const chave of Object.keys(dados)) {
+        const anterior = dono.get(chave);
+        expect(
+          anterior,
+          `chave de topo "${chave}" aparece em ${arquivo}.yaml e em ${anterior}.yaml`,
+        ).toBeUndefined();
+        dono.set(chave, arquivo);
+      }
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Invariantes estritos: en_US e pt_BR precisam estar em paridade.
+// ---------------------------------------------------------------------------
+
+for (const idioma of COMPLETOS) {
+  if (idioma === "en_US") continue;
+
+  test(`${idioma}: nenhum arquivo é esboço vazio`, () => {
+    for (const arquivo of ARQUIVOS) {
+      expect(ehEsboco(idioma, arquivo), `${idioma}/${arquivo}.yaml está vazio`).toBe(false);
+    }
+  });
+
+  for (const arquivo of ["app", "campaign", "items"] as const) {
+    test(`${idioma}/${arquivo}: paridade de chaves com en_US`, () => {
+      const en = achata(carrega("en_US", arquivo));
+      const alvo = achata(carrega(idioma, arquivo));
+      const faltando = Object.keys(en).filter((k) => !(k in alvo));
+      const sobrando = Object.keys(alvo).filter((k) => !(k in en));
+      expect(faltando, `chaves ausentes em ${idioma}/${arquivo}`).toEqual([]);
+      expect(sobrando, `chaves órfãs em ${idioma}/${arquivo}`).toEqual([]);
+    });
+
+    test(`${idioma}/${arquivo}: ids e markup preservados`, () => {
+      const en = achata(carrega("en_US", arquivo));
+      const alvo = achata(carrega(idioma, arquivo));
+      const idsDivergentes = Object.keys(en).filter(
+        (k) => k.endsWith(".id") && alvo[k] !== en[k],
+      );
+      // Os repositórios em src/data/repository fazem lookup por `id`; traduzir um id
+      // quebra a busca silenciosamente.
+      expect(idsDivergentes, `ids traduzidos em ${idioma}/${arquivo}`).toEqual([]);
+
+      const markupDivergente = Object.keys(en).filter(
+        (k) => marcas(en[k]) !== marcas(alvo[k] ?? ""),
+      );
+      expect(markupDivergente, `markup divergente em ${idioma}/${arquivo}`).toEqual([]);
+    });
+  }
+
+  test(`${idioma}/keywords: mesmo conjunto de ids, ícones e markup`, () => {
+    const en = (carrega("en_US", "keywords") as { keyword: any[] }).keyword;
+    const alvo = (carrega(idioma, "keywords") as { keyword: any[] }).keyword;
+
+    const idsEn = en.map((k) => String(k.id));
+    const idsAlvo = alvo.map((k) => String(k.id));
+    expect(
+      idsEn.filter((id) => !idsAlvo.includes(id)),
+      `keywords ausentes em ${idioma}`,
+    ).toEqual([]);
+    expect(
+      idsAlvo.filter((id) => !idsEn.includes(id)),
+      `keywords órfãos em ${idioma} (id renomeado ou removido no en_US)`,
+    ).toEqual([]);
+
+    const porId = new Map(alvo.map((k) => [String(k.id), k]));
+    for (const entrada of en) {
+      const traduzida = porId.get(String(entrada.id))!;
+      // `icon` não é texto: precisa ser idêntico, senão o ícone some ao trocar de idioma.
+      expect(traduzida.icon, `icon divergente em ${idioma} keyword "${entrada.id}"`).toEqual(
+        entrada.icon,
+      );
+      expect(
+        marcas(String(traduzida.description ?? "")),
+        `markup divergente em ${idioma} keyword "${entrada.id}"`,
+      ).toBe(marcas(String(entrada.description ?? "")));
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Defasagem conhecida dos idiomas parcialmente traduzidos.
+// ---------------------------------------------------------------------------
+
+for (const [idioma, maximo] of Object.entries(DEFASAGEM_MAXIMA)) {
+  test(`${idioma}: defasagem de keywords não piorou`, () => {
+    if (ehEsboco(idioma, "keywords")) return;
+    const en = (carrega("en_US", "keywords") as { keyword: any[] }).keyword;
+    const alvo = (carrega(idioma, "keywords") as { keyword: any[] }).keyword;
+    const idsAlvo = new Set(alvo.map((k) => String(k.id)));
+    const ausentes = en.filter((k) => !idsAlvo.has(String(k.id))).length;
+    expect(
+      ausentes,
+      `${idioma} perdeu terreno: ${ausentes} keywords sem tradução (limite ${maximo})`,
+    ).toBeLessThanOrEqual(maximo);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Código x locale: toda chave usada em t()/$t() precisa existir no en_US.
+// ---------------------------------------------------------------------------
+
+/** Formato de uma chave de tradução de verdade: "label.foo", "text.bar-baz". */
+const FORMATO_CHAVE = /^[a-z][a-z0-9-]*(\.[a-z0-9-]+)+$/;
+
+/**
+ * Padrão legado em que a própria frase em inglês é usada como chave — ex.:
+ * t("Delete"), t("Warning"). Renderiza a frase, então funciona em inglês, mas é
+ * intraduzível. Não corrigimos aqui; travamos o número para não se espalhar.
+ */
+const FRASES_COMO_CHAVE_MAXIMO = 33;
+
+function arquivosFonte(dir: string, acc: string[] = []): string[] {
+  for (const entrada of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entrada.name);
+    if (entrada.isDirectory()) {
+      if (entrada.name !== "node_modules") arquivosFonte(p, acc);
+    } else if (
+      (entrada.name.endsWith(".vue") || entrada.name.endsWith(".ts")) &&
+      // artefatos compilados commitados ao lado dos componentes; espelham o .vue
+      !entrada.name.endsWith(".vue.js")
+    ) {
+      acc.push(p);
+    }
+  }
+  return acc;
+}
+
+function mensagensEn(): Dicionario {
+  const todas: Dicionario = {};
+  for (const arquivo of ARQUIVOS) Object.assign(todas, carrega("en_US", arquivo));
+  return todas;
+}
+
+function coletaChaves(): { chaves: Map<string, Set<string>>; frases: Set<string> } {
+  const padrao = /(?:\$t|\bt)\(\s*["'`]([^"'`\n]+)["'`]/g;
+  const chaves = new Map<string, Set<string>>();
+  const frases = new Set<string>();
+  for (const arquivo of arquivosFonte(SRC)) {
+    const conteudo = fs.readFileSync(arquivo, "utf8");
+    const rel = path.relative(RAIZ, arquivo).split(path.sep).join("/");
+    let m: RegExpExecArray | null;
+    while ((m = padrao.exec(conteudo))) {
+      const chave = m[1];
+      if (!FORMATO_CHAVE.test(chave)) {
+        frases.add(chave);
+        continue;
+      }
+      if (!chaves.has(chave)) chaves.set(chave, new Set());
+      chaves.get(chave)!.add(rel);
+    }
+  }
+  return { chaves, frases };
+}
+
+test("toda chave t()/$t() do código existe no en_US", () => {
+  const mensagens = mensagensEn();
+  const existe = (chave: string) =>
+    chave.split(".").reduce<unknown>((a, k) => (a == null ? a : (a as Dicionario)[k]), mensagens) !==
+    undefined;
+
+  const { chaves } = coletaChaves();
+  const ausentes = [...chaves.entries()]
+    .filter(([chave]) => !existe(chave))
+    .map(([chave, arquivos]) => `${chave} (${[...arquivos].join(", ")})`);
+
+  expect(ausentes, "chaves referenciadas no código mas ausentes do en_US").toEqual([]);
+});
+
+test("o padrão legado de frase-como-chave não se espalhou", () => {
+  const { frases } = coletaChaves();
+  expect(
+    frases.size,
+    `use uma chave de tradução ("label.x") em vez da frase em inglês. Encontradas: ${[...frases]
+      .sort()
+      .join(" | ")}`,
+  ).toBeLessThanOrEqual(FRASES_COMO_CHAVE_MAXIMO);
+});

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@tsconfig/node20/tsconfig.json",
+  "include": ["./**/*"]
+}


### PR DESCRIPTION
Fills in the four `src/locales/pt_BR/*.yaml` files, which were empty stubs (`---`) even though `pt_BR` was already wired up in `language.ts`, `LanguageStore` and the `Portuguese` entity.

The base translation comes from the [drunagor-helper](https://github.com/marcojanssen/drunagor-helper) repo and was completed for the content this app has added since: the **Underkeep** expansion and a rewritten keyword catalogue.

## Translation

| File | Keys | Notes |
|---|---|---|
| `items.yaml` | 432 | 82 new Underkeep item names |
| `campaign.yaml` | 1094 | `outcome.underkeep`, `statuses.underkeep`, `statuses.underkeep2` |
| `keywords.yaml` | 223 entries | see below |
| `app.yaml` | 203 | 4 values corrected, not copied |

**`keywords.yaml` was rebuilt by matching on `id`, not array position.** The catalogue was reordered alphabetically and partly renamed, so a verbatim copy would have mapped Portuguese text onto the wrong keywords. Result: 32 newly translated, 36 retranslated where the English text was rewritten, 6 remapped from renamed ids (`cleave-x` → `cleave` and friends), 18 stale ids dropped, and the 29 `icon` values carried over so icons don't disappear when switching language.

**Four `app.yaml` values had to be corrected rather than copied**, because their English text changed meaning since the old repo:

| Key | Old EN | New EN | pt_BR |
|---|---|---|---|
| `label.sequential-adventure` | Sequential Adventure | Start Playing | Começar a Jogar |
| `label.camp-phase` | Camp Phase | reset status | redefinir estados |
| `menu.settings` | Settings | Content | Conteúdo |
| `randomizer.enabled-content` | Enabled variant / content | Enabled content | Conteúdo habilitado |

pt_BR is now the most complete locale after English. For reference, `de_DE`, `fr_FR` and `pl_PL` are still on the pre-Underkeep catalogue.

## Fixes included

- **`src/language.ts`** loaded `en_US/keywords.yaml` as the fallback when a locale's `app.yaml` was empty. Should be `app.yaml`. Still affects `es_ES` and `it_IT`.
- **13 keys referenced by components but missing from every locale** — `error.user-not-logged`, `error.sku-not-found`, `error.campaign-already-exists`, `error.campaign-creation-failed`, `label.error`, `label.class-abilities`, `label.lifepoints`, `label.heroes`, `label.select-card`, `text.no-outcomes`, `text.no-status`, `text.campaign-deleted-success`, `text.error-removing-campaign`. These rendered as the raw key string on screen, including in English. Added to `en_US` and `pt_BR`.

## Tests

`playwright.config.ts` could not run any test: `testDir` pointed at a `tests/` directory that did not exist, `baseURL` still carried the `/drunagor-helper/` path, the `webServer` timeout was 5s, and the readiness probe used `localhost`, which resolves to `::1` on Windows while vite listens on IPv4. Fixed, and the leftover scaffold spec asserting `You did it!` was removed.

**`tests/locales/locale-integrity.spec.ts`** runs without a browser (`npm run test:locales`, ~2s) and guards all seven locales against parse errors, duplicate keys, and collisions between the four namespaces that `language.ts` merges with a shallow spread. For `en_US` and `pt_BR` it also enforces key parity, untranslated `id` fields, icon equality and markup/placeholder parity, and it verifies that every `t()` key used in the source exists in `en_US`. The existing `de_DE`/`fr_FR`/`pl_PL` drift is pinned as a baseline so it cannot get worse.

**`tests/locales/language.spec.ts`** covers loading pt_BR, de_DE (guarding the locale already in production) and the en_US fallback for the still-empty es_ES.

32 tests pass. `npm run build-only` succeeds.

## Two pre-existing issues found, not fixed here

Both predate this branch and are unrelated to translation — flagging rather than fixing, since they sit outside this change:

1. **Deep-linking to `/shared-keywords` throws in every language, English included.** `src/main.ts:27` calls `registerPlugins(app, "prod")` without `await` and mounts immediately, so component setup can run before `loadLanguage()` registers messages; `KeywordDataRepository.load` then reads `i18n.messages.value[locale].keyword` and finds `undefined`. Since that route has no in-app link, deep-linking is its intended use. The language spec therefore enters via the root and navigates through the router.
2. **`npm run type-check` fails with 120 `TS5056` errors on a clean `main`** — the committed `.vue.js` artifacts next to their `.vue` sources collide under `allowJs: true`. Verification here used `build-only`.
